### PR TITLE
Github action fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,7 @@
 name: push_nuget
 
-# on push on master
 on:
-  workflow-dispatch:
+  workflow_dispatch:
     inputs:
       version:
         description: 'The version to push'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,11 +2,12 @@ name: push_nuget
 
 # on push on master
 on:
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - README.md
+  workflow-dispatch:
+    inputs:
+      version:
+        description: 'The version to push'
+        required: false
+        default: 'X.X.X'
 
 jobs:
   build:
@@ -22,10 +23,9 @@ jobs:
       uses: nuget/setup-nuget@v1
 
     - name: Publish VL Nuget
-      uses: vvvv/PublishVLNuget@1.0.29
+      uses: vvvv/PublishVLNuget@1.0.41
       with:
-      #  csproj: src\VL.ShaderFXtension\VL.ShaderFXtension.csproj
-        nuspec: deployment\VL.Fuse.nuspec
-        icon-src: https://raw.githubusercontent.com/vvvv/PublicContent/master/nugeticon.png
-        icon-dst: ./deployment/nugeticon.png
+        csproj: src/Fuse/Fuse.csproj
+        nuspec: deployment/VL.Fuse.nuspec
+        version: ${{ github.event.inputs.version }}
         nuget-key: ${{ secrets.NUGET_KEY }}


### PR DESCRIPTION
- Updates PublishVLNuget to latest version (1.0.41)
- Uncomments and updates path to `csproj`
- Gets rid of automatic build, now uses manual approach
- A version number can be specified when triggering the workflow manually. This version number is then used as a version when publishing to nuget.org