### PR TITLE
Fixes recompile issues with new monadic feature

### DIFF
--- a/src/Fuse/Fuse.csproj
+++ b/src/Fuse/Fuse.csproj
@@ -50,6 +50,6 @@
 
 
   <ItemGroup>
-    <PackageReference Include="VL.Stride.Runtime" Version="2021.4.0-0301-g1e6e81affe" />
+    <PackageReference Include="VL.Stride.Runtime" Version="2021.4.0-0302-g2b83b75aca" />
   </ItemGroup>
 </Project>

--- a/src/Fuse/Monadic.cs
+++ b/src/Fuse/Monadic.cs
@@ -1,6 +1,5 @@
 ﻿using Stride.Graphics;
 using System;
-using System.Diagnostics;
 using VL.Core;
 
 namespace Fuse
@@ -34,14 +33,6 @@ namespace Fuse
             _gpuInput.Value = value;
             return _gpuInput.Output;
         }
-
-        // Called by deserialization and value editor
-        public T Extract(GpuValue<T> sink)
-        {
-            if (sink?.ParentNode is GpuInput<T> gpuInput)
-                return gpuInput.Value;
-            return default;
-        }
     }
 
     // Not sure about this one, never tested it ..
@@ -53,14 +44,6 @@ namespace Fuse
         {
             _textureInput.Value = value;
             return _textureInput.Output;
-        }
-
-        // Shouldn't be called as there's no editor for Texture
-        public Texture Extract(GpuValue<Texture> sink)
-        {
-            if (!(sink?.ParentNode is TextureInput textureInput)) return default;
-            Debug.Assert(textureInput == _textureInput);
-            return textureInput.Value;
         }
     }
 }


### PR DESCRIPTION
The system will always work on the `T` and not `GpuValue<T>`. So for example when creating an IO box it will type it with `T` and not `GpuValue<T>`. Since that IO box is a `T` it can also connected to any other pin of type `T` - what one would've expected in the first place.
The same applies for the values stored in pins.

Note that these changes might break some patches saved yesterday. But I guess those pins/IO boxes will simply turn up red.