### PR TITLE
Constant values lead to shader constants

### DIFF
--- a/src/Fuse/ConstantValue.cs
+++ b/src/Fuse/ConstantValue.cs
@@ -33,6 +33,8 @@ namespace Fuse
         {
             _myValue = theValue;
         }
+
+        public T Value => _myValue;
         
         public override string ID => TypeHelpers.GetDefaultForType<T>(_myValue);
     }

--- a/src/Fuse/Fuse.csproj
+++ b/src/Fuse/Fuse.csproj
@@ -50,6 +50,6 @@
 
 
   <ItemGroup>
-    <PackageReference Include="VL.Stride.Runtime" Version="2021.4.0-0302-g2b83b75aca" />
+    <PackageReference Include="VL.Stride.Runtime" Version="2021.4.0-0333-g73b4631ce4" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Should the user modify the constant (IO box or pin value), the system will switch to a constant buffer upload for that particular value and stick with it until the patch gets restarted (F8/F5).