### PR TITLE
Re-enables automatic testing of VL documents

### DIFF
--- a/PatchTests/PatchTests.cs
+++ b/PatchTests/PatchTests.cs
@@ -1,150 +1,85 @@
 ﻿using NUnit.Framework;
-using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
-using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Reflection;
-using System.Threading;
 using System.Threading.Tasks;
-using System.Windows.Forms;
-using VL.Lang;
-using VL.Lang.Symbols;
-using VL.Model;
-using VVVV.NuGetAssemblyLoader;
+using VL.TestFramework;
 
-namespace MyTests
+namespace Fuse.Tests
 {
-    enum SaveDocCondition { Never, WhenGreen, Always };
-
     [TestFixture]
     public class PatchTests
     {
+        TestEnvironment testEnvironment;
 
-        static string VLVersion = "2021.4.7";
-        static string[] Packs = new string[]{ 
-        
-        //  FIX ME !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-            @"C:\Program Files\vvvv\vvvv_gamma_" + VLVersion + @"\lib\packs",
-
-        };
-
-        // DO YOU WANT TO SAVE THE VL DOCS TO DISK? 
-        static SaveDocCondition SaveDocCondition = SaveDocCondition.Never;
-
-
-        public static IEnumerable<string> NormalPatches()
+        // Watch out: Don't use async Task here. NUnit keeps a synchronization context per async method,
+        // subsequent calls to the session therefor fail with the exception that the context had been shut down.
+        // See https://github.com/nunit/nunit/issues/3500
+        [OneTimeSetUp]
+        public void Setup()
         {
-            var allVLDocs = Directory.GetFiles(MainLibPath, "*.vl", SearchOption.AllDirectories);
-            var allVLDocsWithoutRnD = allVLDocs.Where(f => !f.Contains("R&D"));
+            testEnvironment = CreateEnvironment();
+        }
 
-            var pathUri = new Uri(MainLibPath, UriKind.Absolute);
-            // Yield all your VL docs1
-            //foreach (var file in allVLDocs)
-            foreach (var file in allVLDocsWithoutRnD)
+        [OneTimeTearDown]
+        public void TearDown()
+        {
+            testEnvironment.Dispose();
+            testEnvironment = null;
+        }
+
+        private static TestEnvironment CreateEnvironment()
+        {
+            var vvvvExePath = Task.Run(() => TestEnvironmentLoader.DownloadEntryAssemblyAsync());
+            return TestEnvironmentLoader.Load(vvvvExePath.Result, new[] { MainLibPath, RepositoriesPath });
+        }
+
+        public static IEnumerable<TestCaseData> NormalPatches()
+        {
+            using var testEnv = CreateEnvironment();
+            foreach (var p in testEnv.GetPackages())
             {
-                var fileUri = new Uri(file, UriKind.Absolute);
-                yield return Uri.UnescapeDataString(pathUri.MakeRelativeUri(fileUri).ToString()).Replace("/", @"\");
+                if (p.Identity.Id != "VL.Fuse")
+                    continue;
+
+                foreach (var f in p.Files)
+                {
+                    if (Path.GetExtension(f.AbsolutePath) != ".vl")
+                        continue;
+
+                    if (f.PackagePath.Contains("R&D"))
+                        continue;
+
+                    var testCase = new TestCaseData(f.AbsolutePath)
+                        .SetCategory(p.Identity.ToString())
+                        .SetArgDisplayNames(f.PackagePath);
+
+                    yield return testCase;
+                }
             }
         }
 
 
-
-        public static readonly VLSession Session;
         public static string MainLibPath;
         public static string RepositoriesPath;
 
         static PatchTests()
         {
             var currentDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            MainLibPath = Path.GetFullPath(Path.Combine(currentDirectory, @"..\..\..\..\..\"));
+            MainLibPath = Path.GetFullPath(Path.Combine(currentDirectory, @"..\..\..\..\"));
             RepositoriesPath = Path.GetFullPath(Path.Combine(MainLibPath, @".."));
-
-            foreach (var pack in Packs)
-                AssemblyLoader.AddPackageRepositories(pack);
-
-            // Also add the "vl-libs" folder. The folder that contains our library.
-            AssemblyLoader.AddPackageRepositories(RepositoriesPath);
-
-            Session = new VLSession("gamma", includeUserPackages: false)
-            {
-                CheckSolution = false,
-                IgnoreDynamicEnumErrors = true,
-                NoCache = true,
-                KeepTargetCode = false
-            };
         }
-
-        static Solution FCompiledSolution;
 
 
         /// <summary>
         /// Checks if the document comes with compile time errors (e.g. red nodes). Doesn't actually run the patches.
         /// </summary>
         /// <param name="filePath"></param>
-      //  [TestCaseSource(nameof(NormalPatches))]
-        public static async Task IsntRed(string filePath)
+        [TestCaseSource(nameof(NormalPatches))]
+        public async Task IsntRed(string filePath)
         {
-            filePath = Path.Combine(MainLibPath, filePath);
-            var solution = FCompiledSolution ?? (FCompiledSolution = await CompileAsync(NormalPatches()));
-            var document = solution.GetOrAddDocument(filePath);
-
-            // Check document structure
-            Assert.True(document.IsValid);
-
-            // Check dependenices
-            foreach (var dep in document.GetDocSymbols().Dependencies)
-                Assert.IsFalse(dep.RemoteSymbolSource is Dummy, $"Couldn't find dependency {dep}");
-
-            // Check all containers and process node definitions, including application entry point
-            CheckNodes(document.AllTopLevelDefinitions);
-
-            if (SaveDocCondition == SaveDocCondition.Always || (SaveDocCondition == SaveDocCondition.WhenGreen && Success()))
-                document.Save(isTrusted: false); // TODO: discuss when this can be turned on.
-        }
-
-        private static bool Success()
-        {
-            var thisTest = TestExecutionContext.CurrentContext.CurrentTest;
-            var testResult = thisTest.MakeTestResult();
-            var resultState = testResult.ResultState;
-            return resultState == ResultState.Success || resultState == ResultState.Inconclusive;
-        }
-
-        static async Task<Solution> CompileAsync(IEnumerable<string> docs)
-        {
-            var solution = Session.CurrentSolution;
-            foreach (var f in docs)
-                solution = solution.GetOrAddDocument(Path.Combine(MainLibPath, f)).Solution;
-            return await solution.WithFreshCompilationAsync();
-        }
-
-        public static void CheckNodes(IEnumerable<Node> nodes)
-        {
-            Parallel.ForEach(nodes, definition =>
-            {
-                var definitionSymbol = definition.GetSymbol() as IDefinitionSymbol;
-                Assert.IsNotNull(definitionSymbol, $"No symbol for {definition}.");
-                var errorMessages = definitionSymbol.Messages.Where(m => m.Severity == MessageSeverity.Error);
-                Assert.That(errorMessages.None(), () => $"{definition}: {string.Join(Environment.NewLine, errorMessages)}");
-                Assert.IsFalse(definitionSymbol.IsUnused, $"The symbol of {definition} is marked as unused.");
-            });
-        }
-
-
-
-
-        // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-        // Running Tests patches not supported yet. We for now can only check for compile time errors (like red nodes)
-
-
-        /// <summary>
-        /// Yield all test patches that shall run
-        /// </summary>
-        public static IEnumerable<string> TestPatches()
-        {
-            yield return $@"C:\dev\vl-libs\VL.DemoLib\src\NUnitTests\tests\tests.vl";
+            await testEnvironment.LoadAndTestAsync(filePath);
         }
     }
 }

--- a/PatchTests/PatchTests.csproj
+++ b/PatchTests/PatchTests.csproj
@@ -1,28 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
-    <VLPackageBasePath>..\</VLPackageBasePath>
-    <PackageId>$(AssemblyName)</PackageId>
-    <Description>Test for my library</Description>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <TargetFramework>net6.0</TargetFramework>
 
-    <!-- Triggers stride asset compiler -->
-    <StrideIsExecutable>true</StrideIsExecutable>
-    <VLVersion>2021.4.7</VLVersion>
+    <!-- We do not want Stride to process this assembly as it would add unwanted runtime dependencies into our module ctor prevent the assembly from loading -->
+    <StrideAssemblyProcessor>false</StrideAssemblyProcessor>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VL.Lang" Version="2021.4.7" />
-    <PackageReference Include="VL.Meta.Gamma" Version="2021.4.7" />
-    <PackageReference Include="VL.Stride" Version="2021.4.7" />
-    <PackageReference Include="VL.TestLib" Version="2021.4.7" />
+    <PackageReference Include="VL.TestFramework" Version="2022.5.0-0656-gccbf255842" />
   </ItemGroup>
   <ItemGroup>
     <PackageFile Include="*.vl" />
@@ -31,6 +22,20 @@
     <None Include="*.vl">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Remove="TestComputeSystem.cs" />
+    <Compile Remove="TestControl.cs" />
+    <Compile Remove="TestDynamicStruct.cs" />
+    <Compile Remove="TestGraph.cs" />
+    <Compile Remove="TestTypeHelpers.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TestComputeSystem.cs" />
+    <None Include="TestControl.cs" />
+    <None Include="TestDynamicStruct.cs" />
+    <None Include="TestGraph.cs" />
+    <None Include="TestTypeHelpers.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\Fuse\Fuse.csproj" />

--- a/src/Fuse/Fuse.csproj
+++ b/src/Fuse/Fuse.csproj
@@ -36,8 +36,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Stride.Core.Mathematics" Version="4.1.0.1734" />
-    <PackageReference Include="VL.Stride.Runtime" Version="2022.5.0-0419-gaa3f43a652" />
+    <PackageReference Include="VL.Stride.Runtime" Version="2022.5.0-0636-g80115d4acb" />
   </ItemGroup>
 
 

--- a/src/Fuse/Fuse.csproj
+++ b/src/Fuse/Fuse.csproj
@@ -1,26 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!--TargetFramework>net48</TargetFramework-->
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>default</LangVersion>
-    <Copyright>Copyright ©  2021</Copyright>
+    <Copyright>Copyright © 2023</Copyright>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
-
-  <!-- This replaces the okld AssemblyInfo.cs can be filled out at some point-->
-  <!--
-  <PropertyGroup>
-    <Company>Compiled Expericne</Company>
-    <Authors>Nigel Sampson</Authors>
-    <PackageId>AssemblyDemo</PackageId>
-    <Version>1.0.0</Version>
-    <AssemblyVersion>1.0.1.0</AssemblyVersion>
-    <FileVersion>1.0.1.0</FileVersion>
-  </PropertyGroup>
-  -->
-
-
 
   <PropertyGroup>
     <OutputPath>..\..\lib\</OutputPath>
@@ -36,11 +20,10 @@
 
 
   <ItemGroup>
-    <PackageReference Include="VL.Stride.Runtime" Version="2022.5.0-0636-g80115d4acb" />
+    <PackageReference Include="VL.Stride.Runtime" Version="2022.5.0-0656-gccbf255842">
+      <!-- Development dependency only. At runtime these assemblies are provided by vvvv. -->
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
   </ItemGroup>
 
-
-  <ItemGroup>
-    <Folder Include="Tests" />
-  </ItemGroup>
 </Project>

--- a/src/Fuse/Inputs.cs
+++ b/src/Fuse/Inputs.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using Fuse.compute;
-using Microsoft.CodeAnalysis.Editing;
 using Stride.Graphics;
 using Stride.Rendering;
 using Stride.Rendering.Materials;
@@ -314,7 +313,7 @@ namespace Fuse{
          }
      }
      
-     public class TypedBufferInput<T>: ChangeableObjectInput<Buffer<T>> where T : struct
+     public class TypedBufferInput<T>: ChangeableObjectInput<Buffer<T>> where T : unmanaged
      {
          private bool _append;
 

--- a/src/Fuse/Monadic.cs
+++ b/src/Fuse/Monadic.cs
@@ -144,7 +144,7 @@ namespace Fuse
         }
     }
     
-    internal sealed class BufferGpuValueBuilder<T> : IMonadBuilder<Buffer<T>, ShaderNode<Buffer<T>>> where T : struct
+    internal sealed class BufferGpuValueBuilder<T> : IMonadBuilder<Buffer<T>, ShaderNode<Buffer<T>>> where T : unmanaged
     {
         private readonly TypedBufferInput<T> _bufferInput;
         

--- a/src/Fuse/TypeHelpers.cs
+++ b/src/Fuse/TypeHelpers.cs
@@ -37,17 +37,17 @@ namespace Fuse
              
             // USED BY VL
             // ReSharper disable once UnusedMember.Global 
-            public static void ConstrainTypesByBuffer<T>(ShaderNode<T> input, ShaderNode<Buffer<T>> input2) where T : struct
+            public static void ConstrainTypesByBuffer<T>(ShaderNode<T> input, ShaderNode<Buffer<T>> input2) where T : unmanaged
             {
             }
             
             // USED BY VL
             // ReSharper disable once UnusedMember.Global 
-            public static void ConstrainType<T>(T value, ShaderNode<T> shaderNode, Buffer<T> buffer, ShaderNode<Buffer<T>> gpuBuffer) where T : struct
+            public static void ConstrainType<T>(T value, ShaderNode<T> shaderNode, Buffer<T> buffer, ShaderNode<Buffer<T>> gpuBuffer) where T : unmanaged
             {
             }
             
-            public static void ConstrainBuffer<T>(T value, ShaderNode<T> shaderNode, Buffer<T> buffer, ShaderNode<Buffer<T>> gpuBuffer) where T : struct
+            public static void ConstrainBuffer<T>(T value, ShaderNode<T> shaderNode, Buffer<T> buffer, ShaderNode<Buffer<T>> gpuBuffer) where T : unmanaged
             {
             }
 

--- a/src/Fuse/compute/TypedBufferOperations.cs
+++ b/src/Fuse/compute/TypedBufferOperations.cs
@@ -55,7 +55,7 @@ ${structMembers}
         }
     }
     
-    public class TypedBufferGet<T> : AbstractTypedFunction<T,T> where T : struct
+    public class TypedBufferGet<T> : AbstractTypedFunction<T,T> where T : unmanaged
     {
         private ShaderNode<Buffer<T>> _buffer;
         private ShaderNode<int> _index;
@@ -83,7 +83,7 @@ ${structMembers}
         }
     }
     
-    public class TypedBufferSet<TIn> : AbstractTypedFunction<TIn, GpuVoid>, IComputeVoid where TIn : struct
+    public class TypedBufferSet<TIn> : AbstractTypedFunction<TIn, GpuVoid>, IComputeVoid where TIn : unmanaged
     {
         private ShaderNode<Buffer<TIn>> _buffer;
         private ShaderNode<int> _index;
@@ -125,7 +125,7 @@ ${structMembers}
         }
     }
     
-    public class TypedBufferAppend<T> : AbstractTypedFunction<T, GpuVoid> where T : struct
+    public class TypedBufferAppend<T> : AbstractTypedFunction<T, GpuVoid> where T : unmanaged
     {
         private ShaderNode<Buffer<T>> _buffer;
         private ShaderNode<T> _value;
@@ -164,7 +164,7 @@ ${structMembers}
         }
     }
     
-    public class TypedBufferConsume<T> : AbstractTypedFunction<T,T> where T : struct
+    public class TypedBufferConsume<T> : AbstractTypedFunction<T,T> where T : unmanaged
     {
         private ShaderNode<Buffer<T>> _buffer;
         


### PR DESCRIPTION
Needs #80 

Running the tests the first time can take a little while because it will download and extract the referenced vvvv version in the output folder (if not installed). If this is not wanted it can be configured in a different way, so it always takes a local installation.

Current result looks like this in VS:
![image](https://user-images.githubusercontent.com/573618/221422162-48010a6a-3f42-4786-bc2f-cbe5658a65d9.png)

