### PR TITLE
Only allow connections on `ShaderNode<T>` we actually support

### DIFF
--- a/src/Fuse/Fuse.csproj
+++ b/src/Fuse/Fuse.csproj
@@ -4,9 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <Copyright>Copyright © 2023</Copyright>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-  </PropertyGroup>
 
-  <PropertyGroup>
     <OutputPath>..\..\lib\</OutputPath>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- TODO: i just added 1591 here temporarly. this disables the warnings about -->
@@ -16,12 +14,14 @@
     <!-- copied from vl.stride -->
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
+
+    <PackageRepositories>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\..\..'))</PackageRepositories>
   </PropertyGroup>
 
 
   <ItemGroup>
     <PackageReference Include="JetBrains.Profiler.Api" Version="1.3.0" />
-    <PackageReference Include="VL.Stride.Runtime" Version="2023.5.2">
+    <PackageReference Include="VL.Stride.Runtime" Version="2023.5.3-0251-gc882d50ce8">
       <!-- Development dependency only. At runtime these assemblies are provided by vvvv. -->
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>

--- a/src/Fuse/Monadic.cs
+++ b/src/Fuse/Monadic.cs
@@ -3,11 +3,41 @@ using System;
 using System.Collections.Generic;
 using Fuse.compute;
 using VL.Core;
-using VL.Stride.Rendering.ComputeEffect;
 using Buffer = Stride.Graphics.Buffer;
 
 namespace Fuse
 {
+    internal sealed class ShaderNodeMonadicTypeFilter : IMonadicTypeFilter
+    {
+        public bool Accepts(TypeDescriptor typeDescriptor)
+        {
+            if (typeDescriptor.IsUnmanaged)
+                return true;
+
+            var type = typeDescriptor.ClrType;
+            if (type is null)
+                return false;
+
+            // Read: if (T is Buffer)
+            if (typeof(Buffer).IsAssignableFrom(type))
+                return true;
+
+            if (type == typeof(Texture))
+                return true;
+
+            if (type == typeof(SamplerState))
+                return true;
+
+            if (type == typeof(GpuStruct))
+                return true;
+
+            if (type == typeof(GpuVoid))
+                return true;
+
+            return false;
+        }
+    }
+
     public sealed class ShaderNodeMonadicFactory<T> : IMonadicFactory<T, ShaderNode<T>>
     {
         // This field is accessed by the target code

--- a/src/Fuse/Properties/launchSettings.json
+++ b/src/Fuse/Properties/launchSettings.json
@@ -1,0 +1,14 @@
+{
+  "profiles": {
+    "Normal startup": {
+      "commandName": "Executable",
+      "executablePath": "C:\\Program Files\\vvvv\\vvvv_gamma_5.3-0251-gc882d50ce8\\vvvv.exe",
+      "commandLineArgs": "--package-repositories $(PackageRepositories)"
+    },
+    "Work on Fuse patches": {
+      "commandName": "Executable",
+      "executablePath": "C:\\Program Files\\vvvv\\vvvv_gamma_5.3-0251-gc882d50ce8\\vvvv.exe",
+      "commandLineArgs": "--package-repositories $(PackageRepositories) --editable-packages VL.Fuse"
+    }
+  }
+}

--- a/src/Fuse/ShaderNode.cs
+++ b/src/Fuse/ShaderNode.cs
@@ -637,7 +637,7 @@ namespace Fuse
         }
     }
     
-    [Monadic(typeof(ShaderNodeMonadicFactory<>))]
+    [Monadic(typeof(ShaderNodeMonadicFactory<>), typeof(ShaderNodeMonadicTypeFilter))]
     public class ShaderNode<T> : AbstractShaderNode , IComputeValue<T>
     {
         // ReSharper disable once CollectionNeverQueried.Global


### PR DESCRIPTION
By using newly introduced [`IMonadicTypeFilter`](https://github.com/vvvv/VL.StandardLibs/commit/0c2db1456c97012004f20759dbeaa1d6c592fc12) we can finally restrict the allowed connections to those types we actually support.

Before:
![image](https://github.com/TheFuseLab/VL.Fuse/assets/573618/26b7a141-cf61-46e3-b296-c5a5490ab24d)

After>
![image](https://github.com/TheFuseLab/VL.Fuse/assets/573618/eac29430-e478-49c3-981e-09dd2a05e6f6)