### PR TITLE
Better interop with ShaderFX

### DIFF
--- a/src/Fuse/FuseEffectInstance.cs
+++ b/src/Fuse/FuseEffectInstance.cs
@@ -1,0 +1,86 @@
+﻿using Stride.Core;
+using Stride.Graphics;
+using Stride.Rendering;
+using Stride.Shaders;
+using Stride.Shaders.Compiler;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Fuse
+{
+    public class FuseEffectInstance : EffectInstance
+    {
+        private readonly ShaderSource shaderSource;
+        private readonly IDisposable subscriptions;
+        private EffectSystem effectSystem;
+
+        public FuseEffectInstance(ShaderSource shaderSource, ParameterCollection parameters, IDisposable subscriptions) : base(null, parameters)
+        {
+            this.shaderSource = shaderSource;
+            this.subscriptions = subscriptions;
+        }
+
+        protected override void Destroy()
+        {
+            subscriptions.Dispose();
+            base.Destroy();
+        }
+
+        /// <summary>
+        /// Defines the effect parameters used when compiling this effect.
+        /// </summary>
+        public EffectCompilerParameters EffectCompilerParameters = EffectCompilerParameters.Default;
+
+        public void Initialize(IServiceRegistry services)
+        {
+            this.effectSystem = services.GetSafeServiceAs<EffectSystem>();
+        }
+
+        protected override void ChooseEffect(GraphicsDevice graphicsDevice)
+        {
+            var watch = Stopwatch.StartNew();
+
+            // TODO: Free previous descriptor sets and layouts?
+
+            // Looks like the effect changed, it needs a recompilation
+            var compilerParameters = new CompilerParameters
+            {
+                EffectParameters = EffectCompilerParameters,
+            };
+
+            foreach (var effectParameterKey in Parameters.ParameterKeyInfos)
+            {
+                if (effectParameterKey.Key.Type == ParameterKeyType.Permutation)
+                {
+                    // TODO GRAPHICS REFACTOR avoid direct access, esp. since permutation values might be separated from Objects at some point
+                    compilerParameters.SetObject(effectParameterKey.Key, Parameters.ObjectValues[effectParameterKey.BindingSlot]);
+                }
+            }
+
+            var effectCompiler = effectSystem.Compiler;
+
+            // Setup compilation parameters
+            // GraphicsDevice might have been not valid until this point, which is why we compute platform and profile only at this point
+            compilerParameters.EffectParameters.Platform = GraphicsDevice.Platform;
+            compilerParameters.EffectParameters.Profile = /*graphicsDevice.ShaderProfile ?? */graphicsDevice.Features.RequestedProfile;
+            // Copy optimization/debug levels
+            //compilerParameters.EffectParameters.OptimizationLevel = ;
+            //compilerParameters.EffectParameters.Debug = effectCompilerParameters.Debug;
+
+            // Get the compiled result
+            var compilerResult = effectCompiler.Compile(shaderSource, compilerParameters);
+
+            // Only take the sub-effect
+            var bytecodeTask = compilerResult.Bytecode;
+            var byteCode = bytecodeTask.WaitForResult().Bytecode;
+
+            effect = new Effect(graphicsDevice, byteCode);
+
+            Console.WriteLine($"Compile Time: {watch.ElapsedMilliseconds} ms for Shader {shaderSource}");
+        }
+    }
+}

--- a/src/Fuse/Inputs.cs
+++ b/src/Fuse/Inputs.cs
@@ -411,44 +411,4 @@ namespace Fuse{
             SetFieldDeclaration(TypeHelpers.GetGpuType<T>());
         }
     }
-
-    public interface IComposition
-    {
-        string Declaration { get; }
-        string Name { get; }
-        IComputeNode ComputeNode { get; }
-    }
-
-
-    public class CompositionInput<T> : ShaderNode<T>, IComposition
-        where T : unmanaged
-    {
-        IComputeValue<T> _value;
-
-        public CompositionInput(NodeContext nodeContext, IComputeValue<T> value)
-            : base(nodeContext, "compInput")
-        {
-            _value = value;
-
-            SetProperty(Compositions, this);
-        }
-
-        public string Declaration => ShaderNodesUtil.Evaluate("compose ${compositionType} ${compositionId};", 
-            new Dictionary<string, string>()
-            {
-                { "compositionType", TypeHelpers.GetCompositionType<T>() },
-                { "compositionId", ID }
-            });
-
-        public IComputeNode ComputeNode => _value;
-
-        protected override string SourceTemplate()
-        {
-            return ShaderNodesUtil.Evaluate("${resultType} ${resultName} = ${in}.Compute();",
-                new Dictionary<string, string>
-                {
-                    {"in", ID},
-                });
-        }
-    }
 }

--- a/src/Fuse/Properties/launchSettings.json
+++ b/src/Fuse/Properties/launchSettings.json
@@ -2,12 +2,12 @@
   "profiles": {
     "Normal startup": {
       "commandName": "Executable",
-      "executablePath": "C:\\Program Files\\vvvv\\vvvv_gamma_5.3-0251-gc882d50ce8\\vvvv.exe",
+      "executablePath": "C:\\Program Files\\vvvv\\vvvv_gamma_5.3-0346-g0a53f6c531\\vvvv.exe",
       "commandLineArgs": "--package-repositories $(PackageRepositories)"
     },
     "Work on Fuse patches": {
       "commandName": "Executable",
-      "executablePath": "C:\\Program Files\\vvvv\\vvvv_gamma_5.3-0251-gc882d50ce8\\vvvv.exe",
+      "executablePath": "C:\\Program Files\\vvvv\\vvvv_gamma_5.3-0346-g0a53f6c531\\vvvv.exe",
       "commandLineArgs": "--package-repositories $(PackageRepositories) --editable-packages VL.Fuse"
     }
   }

--- a/src/Fuse/ShaderFX/AbstractToShaderFX.cs
+++ b/src/Fuse/ShaderFX/AbstractToShaderFX.cs
@@ -292,15 +292,19 @@ namespace Fuse.ShaderFX
             }
             if(ShaderNodesUtil.TimeShaderGeneration)Console.WriteLine($"-> Evaluate: {_stopwatch.ElapsedMilliseconds} ms");
 
-            var shaderClassString = new ShaderClassString(ShaderName, ShaderCode);
-
-            var mixin = new ShaderMixinSource();
-            mixin.Mixins.Add(shaderClassString);
+            var shaderSource = new ShaderMixinSource()
+            {
+                Name = ShaderName,
+                Mixins = 
+                {
+                    new ShaderClassString(ShaderName, ShaderCode)
+                }
+            };
 
             foreach (var composition in _compositions)
             {
                 var compositionSource = composition.ComputeNode.GenerateShaderSource(theContext, baseKeys);
-                mixin.AddComposition(composition.Name, compositionSource);
+                shaderSource.AddComposition(composition.CompositionName, compositionSource);
             }
 
             // _parameters = theContext.Parameters;
@@ -313,7 +317,7 @@ namespace Fuse.ShaderFX
            //MeasureProfiler.SaveData(ShaderName);
            //return result;
 
-            return mixin;
+            return shaderSource;
         }
     }
 }

--- a/src/Fuse/ShaderFX/CompositionInput.cs
+++ b/src/Fuse/ShaderFX/CompositionInput.cs
@@ -17,10 +17,10 @@ namespace Fuse.ShaderFX
     {
         IComputeValue<T> _value;
 
-        public CompositionInput(NodeContext nodeContext, IComputeValue<T> value)
+        public CompositionInput(NodeContext nodeContext, SetVar<T> value /* Should just be IComputeValue<T> */)
             : base(nodeContext, "compositionInput")
         {
-            _value = value;
+            _value = value?.Value ?? new VL.Stride.Shaders.ShaderFX.ComputeNode<T>();
 
             SetProperty(Compositions, this);
         }
@@ -29,19 +29,19 @@ namespace Fuse.ShaderFX
             new Dictionary<string, string>()
             {
                 { "compositionType", TypeHelpers.GetCompositionType<T>() },
-                { "compositionId", ID }
+                { "compositionId", CompositionName }
             });
 
         public IComputeNode ComputeNode => _value;
 
-        public string CompositionName => ID;
+        public string CompositionName => $"composition{ID}";
 
         protected override string SourceTemplate()
         {
-            return ShaderNodesUtil.Evaluate("${resultType} ${resultName} = ${in}.Compute();",
+            return ShaderNodesUtil.Evaluate("${resultType} ${resultName} = ${compositionId}.Compute();",
                 new Dictionary<string, string>
                 {
-                    {"in", ID},
+                    {"compositionId", CompositionName},
                 });
         }
     }

--- a/src/Fuse/ShaderNode.cs
+++ b/src/Fuse/ShaderNode.cs
@@ -605,9 +605,9 @@ namespace Fuse
             return PropertyForTree<IGpuInput>(Inputs);
         }
         
-        public List<string> CompositionList()
+        public List<IComposition> CompositionList()
         {
-            return PropertyForTree<string>(Compositions);
+            return PropertyForTree<IComposition>(Compositions);
         }
         
         public List<FieldDeclaration> DeclarationList()


### PR DESCRIPTION
This PR adds a `ShaderFXToFuse` node, showing how to bridge from ShaderFX into FUSE. Can be considered a first step in bringing both systems closer together (see #105).

So far only tested the `Explanation Patching a draw shader` help patch by using above node to feed the Amplitude of the Noise via ShaderFX.