### PR TITLE
Necessary changes for vvvv 6.0

### DIFF
--- a/PatchTests/PatchTests.csproj
+++ b/PatchTests/PatchTests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
 
     <!-- We do not want Stride to process this assembly as it would add unwanted runtime dependencies into our module ctor prevent the assembly from loading -->
     <StrideAssemblyProcessor>false</StrideAssemblyProcessor>
@@ -11,12 +11,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VL.TestFramework" Version="2023.5.3-0386-g70e0f5c115" />
+    <PackageReference Include="VL.TestFramework" Version="2024.6.0-0280-g5542bf5529" />
   </ItemGroup>
   <ItemGroup>
     <PackageFile Include="*.vl" />

--- a/src/Fuse/ConstantValue.cs
+++ b/src/Fuse/ConstantValue.cs
@@ -49,7 +49,7 @@ namespace Fuse
     
     public class ConstantValue<T>: ShaderNode<T>
     {
-        public ConstantValue(T theValue) : base(NodeContext.Default, "constant", null, false)
+        public ConstantValue(T theValue) : base(NodeContext.CurrentRoot, "constant", null, false)
         {
             Value = theValue;
             HasFixedName = true;

--- a/src/Fuse/Fuse.csproj
+++ b/src/Fuse/Fuse.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Copyright>Copyright © 2023</Copyright>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
 
@@ -21,7 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="JetBrains.Profiler.Api" Version="1.3.0" />
-    <PackageReference Include="VL.Stride.Runtime" Version="2023.5.3-0260-g05270d386c">
+    <PackageReference Include="VL.Stride.Runtime" Version="2024.6.0-0280-g5542bf5529">
       <!-- Development dependency only. At runtime these assemblies are provided by vvvv. -->
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>

--- a/src/Fuse/Inputs.cs
+++ b/src/Fuse/Inputs.cs
@@ -146,9 +146,17 @@ namespace Fuse{
              }
          }
 
-         
-         
-         
+
+        // Called by IMonadicValue<T>
+        protected override T GetValue() => Value;
+
+        // Called by IMonadicValue<T>
+        protected override ShaderNode<T> SetValue(T value)
+        {
+            Value = value;
+            return this;
+        }
+
 
          protected void SetFieldDeclaration(string theTypeName, string theComputeTypeName)
          {
@@ -363,12 +371,12 @@ namespace Fuse{
              _typeTracker = theTypeTracker; 
              Value = null;
              Type = theType;
-             
+
              SetInputs( new List<AbstractShaderNode>{Type});
          }
 
      }
-     
+
     public class ValueInput<T> : AbstractInput<T,ValueParameterKey<T>, ValueParameterUpdater<T>> where T : struct 
     {
 
@@ -407,6 +415,9 @@ namespace Fuse{
             ParameterKey = new ValueParameterKey<T>(ID);
             SetFieldDeclaration(TypeHelpers.GetGpuType<T>());
         }
+
+        // Called by IMonadicValue
+        protected override bool HasValue() => true;
     }
     /*
     public class CompositionInput<T> : AbstractInput<IComputeNode,PermutationParameterKey<T>, PermutationParameterUpdater<T>> where T : IComputeNode

--- a/src/Fuse/Monadic.cs
+++ b/src/Fuse/Monadic.cs
@@ -38,150 +38,7 @@ namespace Fuse
         }
     }
 
-    public sealed class ShaderNodeMonadicFactory<T> : IMonadicFactory<T, ShaderNode<T>>
-    {
-        // This field is accessed by the target code
-        public static readonly ShaderNodeMonadicFactory<T> Default = new();
-        
-        private readonly Dictionary<uint, uint> _hashInstances = new();
-
-        IMonadBuilder<T, ShaderNode<T>> IMonadicFactory<T, ShaderNode<T>>.GetMonadBuilder(bool isConstant)
-        {
-            // Not called anymore in 2022.5
-            throw new NotSupportedException();
-        }
-
-        // Will be called once for each data source. The patch editor will also create instances as needed during interaction.
-        public IMonadBuilder<T, ShaderNode<T>> GetMonadBuilder(bool isConstant, NodeContext nodeContext)
-        {
-            // Can't call the constructor directly due to value type constraint
-            if (typeof(T).IsValueType)
-            {
-                // Shader constants disabled for now
-                var builderType = /*isConstant ? typeof(ConstantGpuValueBuilder<>) :*/ typeof(GpuValueBuilder<>);
-                return Activator.CreateInstance(builderType.MakeGenericType( typeof(T)), nodeContext) as IMonadBuilder<T, ShaderNode<T>>;
-            }
-            
-            // Read: if (T is Buffer)
-            if (typeof(Buffer).IsAssignableFrom(typeof(T)))
-            {
-                // Can't call the constructor directly due to value type constraint
-                var builderType = typeof(BufferShaderNodeBuilder<>);
-                return Activator.CreateInstance(builderType.MakeGenericType(typeof(T)), nodeContext) as IMonadBuilder<T, ShaderNode<T>>;
-            }
-            
-            if (typeof(T) == typeof(Texture))
-                return new TextureShaderNodeBuilder(nodeContext) as IMonadBuilder<T, ShaderNode<T>>;
-            
-            if (typeof(T) == typeof(SamplerState))
-                return new SamplerStateGpuValueBuilder(nodeContext) as IMonadBuilder<T, ShaderNode<T>>;
-            
-            if (typeof(T) == typeof(GpuStruct))
-                return new GpuStructBuilder(nodeContext) as IMonadBuilder<T, ShaderNode<T>>;
-            
-            if (typeof(T) == typeof(GpuVoid))
-                return new GpuVoidBuilder(nodeContext) as IMonadBuilder<T, ShaderNode<T>>;
-
-            /*
-            if (typeof(T) == typeof(Buffer))
-                return new BufferGpuValueBuilder<T>() as IMonadBuilder<T, GpuValue<T>>;
-            */
-            throw new NotImplementedException(typeof(T).FullName + "Not Implemented");
-        }
-    }
-
-    // For each data source a builder will be kept
-    internal sealed class GpuValueBuilder<T> : IMonadBuilder<T, ShaderNode<T>>
-        where T : struct
-    {
-        private readonly ValueInput<T> _valueInput;
-        public GpuValueBuilder(NodeContext nodeContext)
-        {
-            _valueInput = new ValueInput<T>(nodeContext);
-        }
-
-        public ShaderNode<T> Return(T value)
-        {
-            _valueInput.Value = value;
-            return _valueInput;
-        }
-    }
-    
-    internal sealed class GpuStructBuilder : IMonadBuilder<GpuStruct, ShaderNode<GpuStruct>>
-        
-    {
-        private readonly DynamicStruct<GpuStruct> _valueInput;
-        public GpuStructBuilder(NodeContext nodeContext)
-        {
-            _valueInput = new DynamicStruct<GpuStruct>(nodeContext, new Dictionary<string, AbstractShaderNode>(), null);
-        }
-
-        public ShaderNode<GpuStruct> Return(GpuStruct value)
-        {
-            return _valueInput;
-        }
-    }
-    
-    internal sealed class GpuVoidBuilder : IMonadBuilder<GpuVoid, ShaderNode<GpuVoid>>
-        
-    {
-        private readonly EmptyVoid _valueInput;
-        public GpuVoidBuilder(NodeContext nodeContext)
-        {
-            _valueInput = new EmptyVoid(nodeContext);
-        }
-
-        public ShaderNode<GpuVoid> Return(GpuVoid value)
-        {
-            return _valueInput;
-        }
-    }
-
-    internal sealed class GpuConstantValueBuilder<T> : IMonadBuilder<T, ShaderNode<T>>
-        where T : struct
-    {
-        private static readonly EqualityComparer<T> EqualityComparer = EqualityComparer<T>.Default;
-
-        private ConstantValue<T> _constantValue;
-        private ValueInput<T> _valueInput;
-
-        private readonly NodeContext _context;
-
-        public GpuConstantValueBuilder(NodeContext nodeContext)
-        {
-            _context = nodeContext;
-        }
-
-        public ShaderNode<T> Return(T value)
-        {
-            if (_valueInput != null)
-            {
-                // The value changed in the past. Stick with the less performant constant buffer upload
-                _valueInput.Value = value;
-                return _valueInput;
-            }
-
-            if (_constantValue is null)
-            {
-                // First time
-                _constantValue = new ConstantValue<T>(value);
-                return _constantValue;
-            }
-
-            if (EqualityComparer.Equals(value, _constantValue.Value))
-            {
-                // Value stayed the same
-                return _constantValue;
-            }
-
-            // Value is changing - switch to different strategy where we upload via constant buffer
-            (_valueInput ??= new ValueInput<T>(_context)).Value = value;
-            return _valueInput;
-        }
-    }
-
-    // Not sure about this one, never tested it ..
-    internal sealed class TextureShaderNodeBuilder : IMonadBuilder<Texture, ShaderNode<Texture>>
+    internal sealed class DelegatingTextureInput : ShaderNode<Texture>
     {
         private TextureInput _textureInput;
 
@@ -189,14 +46,15 @@ namespace Fuse
 
         private readonly TextureTypeTracker _typeTracker;
 
-        public TextureShaderNodeBuilder(NodeContext nodeContext)
+        public DelegatingTextureInput(NodeContext nodeContext)
+            : base(nodeContext, "DelegatingTextureInput", theCreateDefault: false)
         {
             _nodeContext = nodeContext;
             _typeTracker = new TextureTypeTracker(false);
             
         }
 
-        public ShaderNode<Texture> Return(Texture value)
+        protected override ShaderNode<Texture> SetValue(Texture value)
         {
             var changeDeclaration = _typeTracker.CheckDeclaration(value);
             if (changeDeclaration || _textureInput == null)
@@ -208,7 +66,7 @@ namespace Fuse
         }
     }
     
-    internal sealed class BufferShaderNodeBuilder<T> : IMonadBuilder<Buffer, ShaderNode<Buffer>> where T : unmanaged
+    internal sealed class DelegatingBufferInput<T> : ShaderNode<Buffer> where T : unmanaged
     {
         private BufferInput<T> _bufferInput;
 
@@ -216,13 +74,14 @@ namespace Fuse
 
         private readonly BufferTypeTracker<T> _typeTracker;
         
-        public BufferShaderNodeBuilder(NodeContext nodeContext)
+        public DelegatingBufferInput(NodeContext nodeContext)
+            : base(nodeContext, "DelegatingBufferInput", theCreateDefault: false)
         {
             _nodeContext = nodeContext;
             _typeTracker = new BufferTypeTracker<T>(null);
         }
 
-        public ShaderNode<Buffer> Return(Buffer value)
+        protected override ShaderNode<Buffer> SetValue(Buffer value)
         {
             var changeDeclaration = _typeTracker.CheckDeclaration(value);
             if (changeDeclaration || _bufferInput == null)
@@ -231,22 +90,6 @@ namespace Fuse
             }
             _bufferInput.Value = value;
             return _bufferInput;
-        }
-    }
-
-    internal sealed class SamplerStateGpuValueBuilder : IMonadBuilder<SamplerState, ShaderNode<SamplerState>>
-    {
-        private readonly SamplerInput _samplerInput;
-        
-        public SamplerStateGpuValueBuilder(NodeContext nodeContext)
-        {
-            _samplerInput = new SamplerInput(nodeContext);
-        }
-
-        public ShaderNode<SamplerState> Return(SamplerState value)
-        {
-            _samplerInput.Value = value;
-            return _samplerInput;
         }
     }
 }

--- a/src/Fuse/ShaderNodesUtil.cs
+++ b/src/Fuse/ShaderNodesUtil.cs
@@ -397,7 +397,7 @@ namespace Fuse
         
         public NodeContext NextSubContext()
         {
-            if(_context == null)return NodeContext.Default;
+            if(_context == null)return NodeContext.CurrentRoot;
             
             var result = _context.CreateSubContext(new UniqueId("Fuse", _subContextId.ToString()));
             _subContextId++;

--- a/src/Fuse/compute/DynamicIndex.cs
+++ b/src/Fuse/compute/DynamicIndex.cs
@@ -29,7 +29,7 @@ namespace Fuse.compute
     public class VertexIdIndexProvider : IIndexProvider{
         public void Index(NodeContext nodeContext, out ShaderNode<Int3> theReadIndex, out ShaderNode<Int3> theWriteIndex)
         {
-            var vertexId =  new Semantic<int>(NodeContext.Default, "VertexId");
+            var vertexId =  new Semantic<int>(NodeContext.CurrentRoot, "VertexId");
             var join = new Int3Join(nodeContext, vertexId, new ConstantValue<int>(0), new ConstantValue<int>(0));
             theReadIndex = theWriteIndex = join;
         }


### PR DESCRIPTION
We reworked how monadic values (GPU, ShaderNode, Channel, etc.) work in upcoming 6.0 release and therefor some changes in corresponding API were necessary. Once this PR is merged FUSE will need vvvv >= `6.0-0280-g5542bf5529`.

Note that it will not work against the current 6.1 preview build (0003) because that one doesn't have the latest changes from 6.0 merged yet! That's also the reason why this work was based on 9b7814862c0f3a20d964819c6ff3e7474ee31c40 which was the last version of FUSE using a 6.0 preview release. Maybe you should stick to a 6.0 version for the aimed upcoming release.