### PR TITLE
Fixes initialization of FromFloat and ToFloat4

### DIFF
--- a/src/Fuse/ConvertFloat.cs
+++ b/src/Fuse/ConvertFloat.cs
@@ -227,7 +227,7 @@ namespace Fuse
             
             _x = x ?? @default;
             
-            SetInputs(new List<AbstractShaderNode>{x});
+            SetInputs(new List<AbstractShaderNode>{_x});
         }
 
         protected override string ImplementationTemplate()
@@ -294,7 +294,7 @@ namespace Fuse
             
             _x = x ?? @default;
             
-            SetInputs(new List<AbstractShaderNode>{x});
+            SetInputs(new List<AbstractShaderNode>{_x});
         }
 
         protected override string ImplementationTemplate()


### PR DESCRIPTION
Stumbled upon this one while hunting for another error I encountered while following along the fuse raymarching video.

![image](https://github.com/user-attachments/assets/0ad7903b-cb64-4eee-8506-3059ae30f676)
