### PR TITLE
Update ParameterKey OnUpdateName() for TextureInput,BufferInput and SamplerInput

### DIFF
--- a/src/Fuse/Inputs.cs
+++ b/src/Fuse/Inputs.cs
@@ -239,7 +239,8 @@ namespace Fuse{
 
          public override void OnUpdateName()
          {
-             SetFieldDeclaration(TypeTracker.GpuType, TypeTracker.ComputeGpuType);
+            ParameterKey = new ObjectParameterKey<T>(ID);
+            SetFieldDeclaration(TypeTracker.GpuType, TypeTracker.ComputeGpuType);
          }
      }
      
@@ -321,7 +322,8 @@ namespace Fuse{
 
          public override void OnUpdateName()
          {
-             SetFieldDeclaration("SamplerState", "SamplerState");
+            ParameterKey = new ObjectParameterKey<SamplerState>(ID);
+            SetFieldDeclaration("SamplerState", "SamplerState");
          }
      }
 
@@ -388,7 +390,7 @@ namespace Fuse{
              SetInputs( new List<AbstractShaderNode>{Type});
          }
 
-     }
+    }
 
     public class ValueInput<T> : AbstractInput<T,ValueParameterKey<T>, ValueParameterUpdater<T>>, AbstractSetValueInput where T : struct 
     {


### PR DESCRIPTION
Update ParameterKey OnUpdateName for ChangeableObjectInput<T> and SamplerInput

This change is necessary if, 
for example, you have a buffer, a texture or a sampler in a Foreach loop that has the same NodeContext for each iteration.
For this reason, the name in the shader is then changed but the ParameterKey has not been adjusted accordingly. 

This PR fixes the problem.