### PR TITLE
Fixing errors in FuseCoreTransform.sdsl

### DIFF
--- a/vl/shaders/FuseCoreTransform.sdsl
+++ b/vl/shaders/FuseCoreTransform.sdsl
@@ -309,7 +309,7 @@ shader FuseCoreTransform : FuseCoreMath, FuseCommonTypes
 		if (cosTheta > SLERP_DOT_THRESHOLD) // Check after potential flip
 		{
 			// Angle is small, use Nlerp
-			return QuatNormalize(lerp(q1, q2, t));
+			return qNormalize(lerp(q1, q2, t));
 		}
 		else
 		{
@@ -347,7 +347,7 @@ shader FuseCoreTransform : FuseCoreMath, FuseCommonTypes
 			q2 = -q2;
 		}
 
-		return QuatNormalize(lerp(q1, q2, t));
+		return qNormalize(lerp(q1, q2, t));
 	}
 
 
@@ -387,7 +387,7 @@ shader FuseCoreTransform : FuseCoreMath, FuseCommonTypes
 	float4 CreateQuatRotationAxis(float3 axis, float angle)
 	{
 		float3 normAxis = normalize(axis); // Ensure unit axis
-    	float halfAngle = angleRad * 0.5f;
+    	float halfAngle = angle * 0.5f;
     	float s, c;
     	sincos(halfAngle, s, c);
     	return float4(normAxis * s, c);
@@ -426,7 +426,7 @@ shader FuseCoreTransform : FuseCoreMath, FuseCommonTypes
 			}
 			// Calculate the orthogonal axis and create 180-degree rotation quaternion
 			axis = normalize(cross(fromVec, axis));
-			return QuatFromAxisAngle(axis, 3.1415926535f); // PI radians = 180 degrees
+			return CreateQuatRotationAxis(axis, 3.1415926535f); // PI radians = 180 degrees
 		}
 		// General case: Use cross product for axis and calculate w component
 		else


### PR DESCRIPTION
Fixing errors that got introduced in bc50b8984e247ca4e4c6d438117e1d5442273775

When checking the HowTo Fake Fluid patch, I noticed some errors because FuseCoreTransform.sdsl got loaded.
Some things were renamed along the way when reworking this file and not updated everywhere.

I pointed my findings out here:
https://matrix.to/#/!unJZSyUMVrtRlVBaST:matrix.org/$yFr4uR-uYJ0EvttYTzyX43qnC70E8YaiZ_wMN2F8sXo?via=matrix.org&via=t2bot.io&via=monero.social