### PR TITLE
Use shared texture for tooltips / IO boxes

### DIFF
--- a/VL.Fuse.HDE.vl
+++ b/VL.Fuse.HDE.vl
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="Kg1QiXdYpUdMO9nyV2DFJQ" LanguageVersion="2025.7.0-0320-gfcb63b408e" Version="0.128">
+<Document xmlns:p="property" xmlns:r="reflection" Id="Kg1QiXdYpUdMO9nyV2DFJQ" LanguageVersion="2025.7.0-0381-g08d4843fad" Version="0.128">
   <NugetDependency Id="BguWkaXEMADMOCpL1jti9a" Location="VL.CoreLib" Version="2025.7.0-0320-gfcb63b408e" />
   <Patch Id="ALpqjXEf369Pnuk64gmWrV">
     <Canvas Id="V8HBoVZNCZmPvIQ0NbkFQ5" DefaultCategory="Fuse.Core.HDE" CanvasType="FullCategory">
@@ -1758,7 +1758,7 @@
         <Patch Id="DjAz2zPgQSgNuE9IeGTfOp">
           <Canvas Id="FvkdlkbsJTBLl7TnxQydyc" CanvasType="Group">
             <ControlPoint Id="DE1ujkiUDzmMw4xqF8KaAi" Bounds="560,102" />
-            <ControlPoint Id="SgitXAE4nYdNnqssMNbVNR" Bounds="294,1383" />
+            <ControlPoint Id="SgitXAE4nYdNnqssMNbVNR" Bounds="341,1173" />
             <Node Bounds="339,1012,405,19" Id="DyrjxC5fCVZMQNeWOS9HbH">
               <p:NodeReference LastCategoryFullName="Stride" LastDependency="VL.Stride.Runtime.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
@@ -1888,21 +1888,6 @@
               </Pin>
               <Pin Id="LAk3ohBp5h7OFYhQg67SAO" Name="Result" Kind="OutputPin" />
             </Node>
-            <Node Bounds="339,1056,91,19" Id="NIGgSBilY36L67RZ6jXdy0">
-              <p:NodeReference LastCategoryFullName="Stride.Textures" LastDependency="VL.Stride.Runtime.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="ProcessAppFlag" Name="TextureToImage" />
-              </p:NodeReference>
-              <Pin Id="PieUlE16WsNPCuLZ7WmH0Q" Name="Node Context" Kind="InputPin" IsHidden="true" />
-              <Pin Id="EXcpvPIv59uLlokneC1905" Name="Input" Kind="InputPin" />
-              <Pin Id="JKIuPx07GZSLBAZ8MnoDUW" Name="Frame Delay" Kind="InputPin" />
-              <Pin Id="IfMglPqo1C9OFdK3pjTNn4" Name="Size" Kind="InputPin" />
-              <Pin Id="BSJnxVju2W9N74hGeM9nm0" Name="New Format" Kind="InputPin" />
-              <Pin Id="PMTZWxU87AdM9LLsjM3JIq" Name="Output" Kind="OutputPin" />
-              <Pin Id="Ay9ajXdRSPxLBPjANomfO6" Name="Is Blocking" Kind="OutputPin" />
-              <Pin Id="UpdT2Sv5BqrOWdssxxnHfx" Name="Readback Time" Kind="OutputPin" />
-              <Pin Id="Fa2pMUhYApPMqYDThnQQcW" Name="Result Available" Kind="OutputPin" />
-            </Node>
             <Node Bounds="566,579,85,19" Id="NrcK6bGDLf1NvKihMvjcbd">
               <p:NodeReference LastCategoryFullName="Animation" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
@@ -1992,27 +1977,7 @@
               <Pin Id="TKsSBu5MfdYL1PzY1EWZlS" Name="Input" Kind="InputPin" />
               <Pin Id="UL1USWDXD57MmAOYGS7Soe" Name="Result" Kind="OutputPin" />
             </Node>
-            <Node Bounds="292,1315,86,19" Id="C7mQDmufEBLOFbGNurSOMI">
-              <p:NodeReference LastCategoryFullName="HDE.TooltipWidgets" LastDependency="VL.HDE.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="ProcessAppFlag" Name="SKImageWidget" />
-              </p:NodeReference>
-              <Pin Id="L5U4ALKZN4OPeoPYFXays5" Name="Node Context" Kind="InputPin" IsHidden="true" />
-              <Pin Id="HoU08bTMFb8NvOb2RvAeAK" Name="Value" Kind="InputPin" />
-              <Pin Id="ClcExpDyockOT63k64Uv2o" Name="Paint" Kind="InputPin" />
-              <Pin Id="UZ4bhFy125DLYzL0NO5oMJ" Name="Size" Kind="InputPin" DefaultValue="2">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                  <Choice Kind="TypeFlag" Name="Float32" />
-                </p:TypeAnnotation>
-              </Pin>
-              <Pin Id="FcEtfFeZvsvQZqwtJsJqu6" Name="Checkerboard" Kind="InputPin" DefaultValue="False">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                  <Choice Kind="TypeFlag" Name="Boolean" />
-                </p:TypeAnnotation>
-              </Pin>
-              <Pin Id="M7Hf2sDQNQAQKjxtTWwNVy" Name="Output" Kind="StateOutputPin" />
-            </Node>
-            <Pad Id="NzepYQxLBIZP0BalHxddZR" Comment="Size" Bounds="348,1299,35,15" ShowValueBox="true" isIOBox="true" Value="1">
+            <Pad Id="NzepYQxLBIZP0BalHxddZR" Comment="Size" Bounds="367,1090,35,15" ShowValueBox="true" isIOBox="true" Value="1">
               <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
@@ -2029,7 +1994,7 @@
               <Pin Id="NbFGSxaGoDYPx7scPycwr8" Name="Enabled" Kind="InputPin" />
               <Pin Id="CD58PzVIM0WLl2XGzXkPAW" Name="Output" Kind="OutputPin" />
             </Node>
-            <Node Bounds="400,847,125,19" Id="UCeXY865ls6N54XB05TYx1">
+            <Node Bounds="400,847,145,19" Id="UCeXY865ls6N54XB05TYx1">
               <p:NodeReference LastCategoryFullName="Stride" LastDependency="VL.Stride.Runtime.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="Entity" />
@@ -2105,84 +2070,6 @@
                 <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
               </p:ValueBoxSettings>
             </Pad>
-            <Node Bounds="292,1132,99,19" Id="DvRjLEBIfqQNsK8Fdo65oA">
-              <p:NodeReference LastCategoryFullName="Fuse.Core.HDE" LastDependency="VL.Fuse.HDE.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="ProcessAppFlag" Name="PreventWhiteFlash" />
-              </p:NodeReference>
-              <Pin Id="KDbdwVyMZZ8NDsFvkUvM44" Name="Node Context" Kind="InputPin" IsHidden="true" />
-              <Pin Id="JSGCYMmgrXqOjJRRCKh0Ef" Name="Initial Color" Kind="InputPin" />
-              <Pin Id="RTTFlKbXMGrQM9vpuxDB0q" Name="Image" Kind="InputPin" />
-              <Pin Id="NIJnph8svbCLSoORFQpWJu" Name="Frames To Wait" Kind="InputPin" />
-              <Pin Id="CUWODM15c2CPvggNSTzRQw" Name="Output" Kind="OutputPin" />
-              <Pin Id="TjRRH7E7NkXNZXJHFeenOF" Name="Enabled" Kind="OutputPin" />
-            </Node>
-            <Pad Id="Ex2ipX6ivS8OJnoVhtd8P1" Comment="Frames To Wait" Bounds="388,1107,35,15" ShowValueBox="true" isIOBox="true" Value="3">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="TypeFlag" Name="Integer32" />
-              </p:TypeAnnotation>
-            </Pad>
-            <Node Bounds="319,1258,80,19" Id="PyiWOltANecNRwBh7B21Bx">
-              <p:NodeReference LastCategoryFullName="Graphics.Skia.Paint" LastDependency="VL.Skia.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="ProcessAppFlag" Name="SetBlendMode" />
-                <CategoryReference Kind="Category" Name="Paint" NeedsToBeDirectParent="true">
-                  <p:OuterCategoryReference Kind="Category" Name="Skia" NeedsToBeDirectParent="true" />
-                </CategoryReference>
-              </p:NodeReference>
-              <Pin Id="UQVhTBkIhPBLpZX5m92DaT" Name="Node Context" Kind="InputPin" IsHidden="true" />
-              <Pin Id="LAG7avXYMRsNnEw1xcD5Ov" Name="Input" Kind="InputPin" />
-              <Pin Id="BjZAhuEfNNqNbZWqfIEVXg" Name="Value" Kind="InputPin" DefaultValue="SrcOver">
-                <p:TypeAnnotation LastCategoryFullName="Graphics.Skia.Unwrapped.Enums" LastDependency="VL.Skia.vl">
-                  <Choice Kind="TypeFlag" Name="SKBlendMode" />
-                </p:TypeAnnotation>
-              </Pin>
-              <Pin Id="Tpyy6t460krNFdN2coJAes" Name="Output" Kind="OutputPin" />
-            </Node>
-            <Node Bounds="390,1163,125,19" Id="EuTiBKrt7lcLkJdfYf6hJp">
-              <p:NodeReference LastCategoryFullName="Animation" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="ProcessAppFlag" Name="Damper" />
-              </p:NodeReference>
-              <Pin Id="GjSmvE382GxONZSd9BluPb" Name="Node Context" Kind="InputPin" IsHidden="true" />
-              <Pin Id="O6ACs030cOiQOQRQc4T47L" Name="Clock" Kind="InputPin" />
-              <Pin Id="DsK3VV32pDGPMQow5YiZMd" Name="New Clock" Kind="InputPin" />
-              <Pin Id="FOiWpuNfdveMHohq3vExWq" Name="Goto Position" Kind="InputPin" />
-              <Pin Id="EoXMHqaHzGhOQNTXE3cuG1" Name="Filter Time" Kind="InputPin" DefaultValue="0.5">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                  <Choice Kind="TypeFlag" Name="Float32" />
-                </p:TypeAnnotation>
-              </Pin>
-              <Pin Id="IYoRGQjW5gdPpePa3vr2RL" Name="Cyclic" Kind="InputPin" />
-              <Pin Id="AAoSimnaRbfPPWFUOwkX6W" Name="Jump" Kind="InputPin" />
-              <Pin Id="U4W1zQKsTGILpd8LlN6IC8" Name="Force New Func" Kind="InputPin" />
-              <Pin Id="ClMs9d3loDDO2ISAlH56lw" Name="Position" Kind="OutputPin" />
-              <Pin Id="RMH6McmWqF3OXGyJwI0sTC" Name="Velocity" Kind="OutputPin" />
-              <Pin Id="RDvjhL4ghDiMpLJSN0zk4e" Name="Acceleration" Kind="OutputPin" />
-              <Pin Id="G7uGmeR2sGDPkp2AIrFoIG" Name="Function" Kind="OutputPin" />
-              <Pin Id="NKBuXzPKW5hOOAShDoajt8" Name="Has Changed" Kind="OutputPin" />
-            </Node>
-            <Node Bounds="319,1225,45,19" Id="S1RQrBerIENPwOwjGyfXgv">
-              <p:NodeReference LastCategoryFullName="Graphics.Skia.Paint" LastDependency="VL.Skia.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="ProcessAppFlag" Name="Fill" />
-              </p:NodeReference>
-              <Pin Id="Hb5zgsRRAwiLdAQA9I8egP" Name="Node Context" Kind="InputPin" IsHidden="true" />
-              <Pin Id="JfzaemdK2dmOSKVLziSYDA" Name="Input" Kind="InputPin" />
-              <Pin Id="NIlU0A3XFCFN0r9PWwnT0Z" Name="Color" Kind="InputPin" />
-              <Pin Id="PfpHTUeSVs4NJxIVpSmaln" Name="Shader" Kind="InputPin" />
-              <Pin Id="TCZkasWiXXDMNCrnTu0FNR" Name="Output" Kind="OutputPin" />
-            </Node>
-            <Node Bounds="339,1193,56,19" Id="Q1FG9s1zIwQND92iHg291t">
-              <p:NodeReference LastCategoryFullName="Color.RGBA" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="SetAlpha" />
-                <CategoryReference Kind="ColorRGBAType" Name="RGBA" NeedsToBeDirectParent="true" />
-              </p:NodeReference>
-              <Pin Id="M4cQtfgXLOVOQvPMNdqAix" Name="Input" Kind="StateInputPin" />
-              <Pin Id="RKCZK4oIFpEOBvWV9Hq7QN" Name="Alpha" Kind="InputPin" />
-              <Pin Id="TIffgzMxNwUOipAHbeZM3G" Name="Output" Kind="StateOutputPin" />
-            </Node>
             <Node Bounds="558,161,102,90" Id="OYJT78uuNgpN6RlPFPt99B">
               <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
@@ -2326,6 +2213,18 @@
             <ControlPoint Id="VTMHPBhnrbfPUmhghufjBu" Bounds="248,717" />
             <ControlPoint Id="F8izjdNSjgjQSQ3HqMoMlf" Bounds="577,959" />
             <ControlPoint Id="JMBOCftHaTSOReskSb4ayj" Bounds="785,754" />
+            <Node Bounds="339,1110,83,19" Id="GmoxvmCoFYDMzY9aGR7Ghn">
+              <p:NodeReference LastCategoryFullName="Stride.HDE" LastDependency="VL.Stride.HDE.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="ProcessAppFlag" Name="TextureWidget" />
+              </p:NodeReference>
+              <Pin Id="HJOFNae8USXMLNizweKIXL" Name="Node Context" Kind="InputPin" IsHidden="true" />
+              <Pin Id="TEASsSPl847OqksjIhN0Pz" Name="Input" Kind="InputPin" />
+              <Pin Id="KpFRtsxNdpEOSF0VYY4JMW" Name="Widget Size" Kind="InputPin" />
+              <Pin Id="A1XPKxRMygyPJdCBMR2taA" Name="Reset" Kind="InputPin" />
+              <Pin Id="OKv62JoYhTOMKbax4rQzLa" Name="Max Texture Size" Kind="InputPin" />
+              <Pin Id="NrBLlHm3YqwOrJl7lANE6w" Name="Widget" Kind="OutputPin" />
+            </Node>
           </Canvas>
           <ProcessDefinition Id="HFvToWsIaK1LweZBDqwT6U">
             <Fragment Id="SbUUodMi3NzLGeG00Xp7FM" Patch="EyIYQQfri2WMBECTYzmrWa" Enabled="true" />
@@ -2339,7 +2238,6 @@
           <Link Id="AyazaHl9x98L1VVZRzaBCs" Ids="C3JwRc8MEU8L9PZHEJ1Z99,NL4OHKb499hO6RG3xKJiq6" />
           <Link Id="HMsk1xkbsZFLZJYpaIMNSF" Ids="C3JwRc8MEU8L9PZHEJ1Z99,F8izjdNSjgjQSQ3HqMoMlf,KRy1i3lkW4IQEFegYg4Hhv" />
           <Link Id="IZHpoxlxKEEPIAQkuzDhoe" Ids="LAk3ohBp5h7OFYhQg67SAO,A2Klo3O1uf5MDshZEw6FQv" />
-          <Link Id="Kadq5eDWPAGORN7SNFMYg3" Ids="LIqsW0Px79wNjJ7svfzmZF,EXcpvPIv59uLlokneC1905" />
           <Link Id="NtpruBaQ5SOPb9YVw5HTCS" Ids="IICJ8nQsR88MZWeN4tgeY7,Hg3MGN14WGKK9gHuDuZXQG" />
           <Link Id="Q9kupdVHyLcPWP40CO2X0m" Ids="FvCpeL0ru15O5FBWpe0r70,BDhsuEd9fYXLvXsEpW2H41" />
           <Link Id="C2uSANo9GVcOXsvIZ3z3gq" Ids="I4UdikUWJhPOEUFJJNc0Lk,DThlQKkVtj6OZl5FNGsuXX" />
@@ -2348,7 +2246,6 @@
           <Link Id="HOc2mRKfpbQLceZ6Tmgw3l" Ids="DkQ9R7OXY7PNVq1nzu8kBU,JMBOCftHaTSOReskSb4ayj,OcCIgk9kbflMdw15Cquq3Q" />
           <Link Id="GrBfQtU6UCzNdHPKc6LRUX" Ids="MIayiEs3TczLZyHIWO8lQv,I2N3o1OzxBkLUNmPIqPOhG" />
           <Link Id="IbtE3tBDTDvNyNEOwX0RR8" Ids="UL1USWDXD57MmAOYGS7Soe,S51pdyqlekjPTJ6G46fr9T" />
-          <Link Id="BkfxHer0kp3NysKY08QQs8" Ids="NzepYQxLBIZP0BalHxddZR,UZ4bhFy125DLYzL0NO5oMJ" />
           <Link Id="LmhFAnceGTnOuqX3vfGRdl" Ids="H8kVBNoH5pSOIFc2xGZLZt,BXoDr6FbyITO1jixpkV30T" />
           <Link Id="Hyg33hR5y6OP5Tn2kYj3Qw" Ids="CD58PzVIM0WLl2XGzXkPAW,QIjLqrLtxbWOMLVEvBuT1d" />
           <Link Id="LcfrBiCwefwNO4jesOudxT" Ids="NP24XTNi82gOhctB3V7KGC,BGzPWDmXwZwPfJuT3X7hQ9" />
@@ -2368,16 +2265,7 @@
           <Link Id="Sqkn10sgD6tLqbBkFoQNCh" Ids="DE1ujkiUDzmMw4xqF8KaAi,BUYavUgkL1eLoZjV8XIDud" />
           <Link Id="HT9bxkVLpzTMjCl6pgHDrp" Ids="OoezZ02aCF9Mqg1hUt26ub,TKsSBu5MfdYL1PzY1EWZlS" />
           <Link Id="Ohu5unOw7HuMOzQBO8VeqU" Ids="D49y9lDnqMbLpOFPxUWKIb,LmbrGrYmqfxO7QhTrXkuVV" />
-          <Link Id="MpTlMUeUgGRPfKYV14YF5u" Ids="PMTZWxU87AdM9LLsjM3JIq,RTTFlKbXMGrQM9vpuxDB0q" />
-          <Link Id="IlG4NUPlHnsNYiWpagtGyq" Ids="CUWODM15c2CPvggNSTzRQw,HoU08bTMFb8NvOb2RvAeAK" />
-          <Link Id="LNgqep9HSphQMheMmX6g6k" Ids="Ex2ipX6ivS8OJnoVhtd8P1,NIJnph8svbCLSoORFQpWJu" />
-          <Link Id="CwRExFk3UDZMeCPw8Zmoeq" Ids="M7Hf2sDQNQAQKjxtTWwNVy,SgitXAE4nYdNnqssMNbVNR" />
           <Link Id="VifD2tDaUmBOyWWsCKqxA4" Ids="Vwh4gjxPbCjMxTG5hJuo9R,FpQ9u4DScqLP8kKhnReZRv" />
-          <Link Id="ESHnFSpH6a5O4hRhYwl7YR" Ids="Tpyy6t460krNFdN2coJAes,ClcExpDyockOT63k64Uv2o" />
-          <Link Id="HdGqJxZr0IqM0q6doO6x46" Ids="TjRRH7E7NkXNZXJHFeenOF,FOiWpuNfdveMHohq3vExWq" />
-          <Link Id="L0IhfBTZZmnNf9SIjU9r6K" Ids="ClMs9d3loDDO2ISAlH56lw,RKCZK4oIFpEOBvWV9Hq7QN" />
-          <Link Id="GICyuxASzfnOkU1yJ4re6L" Ids="TIffgzMxNwUOipAHbeZM3G,NIlU0A3XFCFN0r9PWwnT0Z" />
-          <Link Id="OifRI2sDpNSMOWeJXyQq90" Ids="TCZkasWiXXDMNCrnTu0FNR,LAG7avXYMRsNnEw1xcD5Ov" />
           <Link Id="JXAAMoaVGuQM45GRIecaHa" Ids="DE1ujkiUDzmMw4xqF8KaAi,DxVg48pCnPNMndiFH4o4Ka" />
           <Link Id="N9yQNC5oG5VNcyJEqvfrrF" Ids="EYNpExZUiixLUPNw0xPAof,PlJPpfMrF9gPagA59FkdQ7" />
           <Link Id="QsfLDhoBwtRLAn4CVGwuGa" Ids="Ek1weusURZWM8BUnRT2CJZ,RMONs3J4iuyLmtycR8iL6J" IsFeedback="true" />
@@ -2403,7 +2291,6 @@
           <Link Id="N0DnFuX6zYENG0U3NUymfE" Ids="BEo6nNM1Vj9P5mpx4lM0uB,P0pRc2wUGUxO22s2fvP06G" />
           <Link Id="KM6DWCxe24BLBtuoaxAA9I" Ids="UXkgQQWGJUXQNGqFF7vyMR,I4q801pK1ofLuQeQrGh0hW" />
           <Link Id="OY8xwqS8rAYQMwhg7MuUYY" Ids="DVBSp1238tsO9OK5toOBGy,D1VoRWZTmNYNyBrvwPKU9i" />
-          <Link Id="SXV0ZjFA6qCPsvUgulQ42b" Ids="UXkgQQWGJUXQNGqFF7vyMR,IfMglPqo1C9OFdK3pjTNn4" />
           <Link Id="EU96INRwrn7MyxwBebpHrO" Ids="JjiYO5lQaj1PgJuBp4o0EX,VTMHPBhnrbfPUmhghufjBu" IsHidden="true" />
           <Link Id="Mksnz2SJLPaLYIqarjMgZ7" Ids="VTMHPBhnrbfPUmhghufjBu,EVnayT35OudLVMUoO8jEpt" />
           <Patch Id="EyIYQQfri2WMBECTYzmrWa" Name="Create">
@@ -2432,6 +2319,9 @@
             </Pin>
             <Pin Id="TPPcyivtGmtMb6VfJn2rHU" Name="Widget" Kind="OutputPin" />
           </Patch>
+          <Link Id="Hy5QeBjPe8zPvVG43VKRjx" Ids="LIqsW0Px79wNjJ7svfzmZF,TEASsSPl847OqksjIhN0Pz" />
+          <Link Id="IzXlTdmLbA2MldCxQUuMp5" Ids="NrBLlHm3YqwOrJl7lANE6w,SgitXAE4nYdNnqssMNbVNR" />
+          <Link Id="A1A7KcDViwcNUziYJlcFiQ" Ids="NzepYQxLBIZP0BalHxddZR,KpFRtsxNdpEOSF0VYY4JMW" />
         </Patch>
       </Node>
       <!--
@@ -2445,92 +2335,13 @@
         </p:NodeReference>
         <Patch Id="BMFQUoM5q0VOzcBcjktFI5">
           <Canvas Id="HWDzsfYNyLdPjm4mFhcHrC" CanvasType="Group">
-            <ControlPoint Id="So9tDFXbgvoNfx0orRIKpm" Bounds="514,829" />
+            <ControlPoint Id="So9tDFXbgvoNfx0orRIKpm" Bounds="396,701" />
             <ControlPoint Id="NnnoCvs8o2YNr3gAxTL7Yn" Bounds="413,500" />
             <Pad Id="Oaq6k7VOVvUQGwHPjwCNql" Comment="Size" Bounds="565,360,35,28" ShowValueBox="true" isIOBox="true" Value="400, 400">
               <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Int2" />
               </p:TypeAnnotation>
             </Pad>
-            <Node Bounds="392,552,91,19" Id="PC3U2NfCMeVMbb0MivxRDE">
-              <p:NodeReference LastCategoryFullName="Stride.Textures" LastDependency="VL.Stride.Runtime.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="ProcessAppFlag" Name="TextureToImage" />
-              </p:NodeReference>
-              <Pin Id="KXdGe1kVMPDLtnTETIp1wp" Name="Node Context" Kind="InputPin" IsHidden="true" />
-              <Pin Id="ESNsVDQTiexOPXuKwVVrVe" Name="Input" Kind="InputPin" />
-              <Pin Id="ODS0ZLGm8Z5O6XnxFC6eCI" Name="Frame Delay" Kind="InputPin" />
-              <Pin Id="Sj63Ns3RwFoLupHcKFmssI" Name="Size" Kind="InputPin" />
-              <Pin Id="Ctfm4pQVyeANhYiQUMZ1ml" Name="New Format" Kind="InputPin" />
-              <Pin Id="VMAAm4iV1i6Nqm4Ke1aiVe" Name="Output" Kind="OutputPin" />
-              <Pin Id="IuxPlG5Bwc3QPA6aCmkrlT" Name="Is Blocking" Kind="OutputPin" />
-              <Pin Id="DiJNpqdCCpZPPP6cTMUWCc" Name="Readback Time" Kind="OutputPin" />
-              <Pin Id="ILtvsSKuqRNOXTIjlQARkD" Name="Result Available" Kind="OutputPin" />
-            </Node>
-            <Node Bounds="477,615,145,180" Id="LAo7Yxp9lTMMWtaplJ2noo">
-              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
-                <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
-                <Choice Kind="ApplicationStatefulRegion" Name="If" />
-                <CategoryReference Kind="Category" Name="Primitive" />
-              </p:NodeReference>
-              <Pin Id="F1b2flF8R3fNNd7yHP3lBP" Name="Condition" Kind="InputPin" />
-              <ControlPoint Id="Vnastc2AjGkPYPZKYzwW9T" Bounds="514,789" Alignment="Bottom" />
-              <ControlPoint Id="LCZT85Po43AQX3ZB2nzNAE" Bounds="514,621" Alignment="Top" />
-              <Patch Id="IDMRN9PLGvRMCbzDXm27PI" ManuallySortedPins="true">
-                <Patch Id="JH3zuOa4QcjNiB6Tp071uO" Name="Create" ManuallySortedPins="true" />
-                <Patch Id="EVyral21B2ROqusm4Iupb8" Name="Then" ManuallySortedPins="true" />
-                <Node Bounds="500,654,82,26" Id="R2CPgbCqfswOLtJAM0oHod">
-                  <p:NodeReference LastCategoryFullName="Graphics.Skia.Imaging" LastDependency="VL.Skia.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="Category" Name="Imaging" NeedsToBeDirectParent="true" />
-                    <Choice Kind="OperationCallFlag" Name="TryFromImage" />
-                  </p:NodeReference>
-                  <Pin Id="T5dFcH01wmdOPahMYJpSHP" Name="Input" Kind="InputPin" />
-                  <Pin Id="Tf2WcqmWB9JMgPEy4DQMuj" Name="Discard Higher Bits" Kind="InputPin" />
-                  <Pin Id="FgI3errNhHtLZlPX6CdeL7" Name="Result" Kind="OutputPin" />
-                  <Pin Id="U063PN7DOcPOri6Yu4IUff" Name="Image" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="500,696,110,79" Id="Bot1gmiuD5DMosULYdqi4S">
-                  <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
-                    <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
-                    <Choice Kind="ApplicationStatefulRegion" Name="If" />
-                    <CategoryReference Kind="Category" Name="Primitive" />
-                  </p:NodeReference>
-                  <Pin Id="H8Ut25cZNd0OAzZUKjOYuD" Name="Condition" Kind="InputPin" />
-                  <ControlPoint Id="CpjY4rlzU4MOM3nfgVnpD4" Bounds="514,769" Alignment="Bottom" />
-                  <ControlPoint Id="R8Ze2hQtP2EON0oDSjEsLv" Bounds="514,702" Alignment="Top" />
-                  <Patch Id="SnWC87ieNA8P7VdgpWaM2N" ManuallySortedPins="true">
-                    <Patch Id="IHKlXYVTR6APRZLfJUzwph" Name="Create" ManuallySortedPins="true" />
-                    <Patch Id="SBn0jmRZI1IMZENg5ZoFBd" Name="Then" ManuallySortedPins="true" />
-                    <Node Bounds="512,727,86,19" Id="J8shsbyfsV0P7gQgUjdQcS">
-                      <p:NodeReference LastCategoryFullName="HDE.TooltipWidgets" LastDependency="VL.HDE.vl">
-                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                        <Choice Kind="ProcessNode" Name="SKImageWidget" />
-                      </p:NodeReference>
-                      <Pin Id="MG4hjaIt9h4LcN2Ucugoxs" Name="Node Context" Kind="InputPin" IsHidden="true" />
-                      <Pin Id="OPPoa6vSECjNyAb681gD1L" Name="Value" Kind="InputPin" />
-                      <Pin Id="N6WEQ4GaMrhLadwkMQh4Oe" Name="Paint" Kind="InputPin" />
-                      <Pin Id="QDPpDz1U1P8P3Ka56rtsq6" Name="Size" Kind="InputPin" />
-                      <Pin Id="EviT1tmXa6HLnn0esgq3Nk" Name="Checkerboard" Kind="InputPin" />
-                      <Pin Id="N5PPaRNbXdSPC02dkB8FJw" Name="Output" Kind="StateOutputPin" />
-                    </Node>
-                  </Patch>
-                </Node>
-              </Patch>
-            </Node>
-            <Node Bounds="512,573,76,19" Id="ANhqj8huSEsNRlJQvIswpG">
-              <p:NodeReference LastCategoryFullName="HDE.TooltipWidgets" LastDependency="VL.HDE.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="ProcessAppFlag" Name="EmptyWidget" />
-              </p:NodeReference>
-              <Pin Id="ML9qUROlKCMLVhaDZbQhQ4" Name="Node Context" Kind="InputPin" IsHidden="true" />
-              <Pin Id="Cbgy2dIYLaqPYhdi3ni8xR" Name="Default Size" Kind="InputPin" DefaultValue="1, 1">
-                <p:TypeAnnotation LastCategoryFullName="2D" LastDependency="VL.CoreLib.vl">
-                  <Choice Kind="TypeFlag" Name="Vector2" />
-                </p:TypeAnnotation>
-              </Pin>
-              <Pin Id="BhMUpPIhwn8PLAunvdJwJn" Name="Output" Kind="StateOutputPin" />
-            </Node>
             <Node Bounds="394,420,105,19" Id="SN2Y7EsDJqWM7x3nk31HGo">
               <p:NodeReference LastCategoryFullName="Fuse.Util" LastDependency="Fuse.Core.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
@@ -2549,151 +2360,6 @@
             </Node>
             <ControlPoint Id="HPm9LI0ud0mLfq9wlt2Etq" Bounds="395,325" />
             <ControlPoint Id="LbMwpgstKOnP59ItRqntyT" Bounds="476,323" />
-            <Node Bounds="779,523,247,467" Id="FuYgp668bEnLUTrRcIdVtM">
-              <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
-                <CategoryReference Kind="Category" Name="Control" />
-                <Choice Kind="ProcessAppFlag" Name="Comment" />
-              </p:NodeReference>
-              <Pin Id="MZr3I4gytjtNxuLqM4CCzY" Name="Node Context" Kind="InputPin" IsHidden="true" />
-              <Patch Id="RU5Cdhv3FQDQDCIM1Kd1eE" ManuallySortedPins="true">
-                <Node Bounds="838,627,91,19" Id="HWrqINTkulsPOXSvuluBzp">
-                  <p:NodeReference LastCategoryFullName="Stride.Textures" LastDependency="VL.Stride.Runtime.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <Choice Kind="ProcessAppFlag" Name="TextureToImage" />
-                  </p:NodeReference>
-                  <Pin Id="M6UwnG4EylqPigKdP7FiLD" Name="Node Context" Kind="InputPin" IsHidden="true" />
-                  <Pin Id="Br1t7ofzZ27LUxgnlOkQ5x" Name="Input" Kind="InputPin" />
-                  <Pin Id="GwKIAisW6jTO7J03BGn69d" Name="Frame Delay" Kind="InputPin" />
-                  <Pin Id="TqmX1EIgnDtQQQypr2L4Sl" Name="Size" Kind="InputPin" />
-                  <Pin Id="Aty2C0arYXMOWGlR7DHTgX" Name="New Format" Kind="InputPin" />
-                  <Pin Id="HjoH2GjkzyJLKmVtV2OSRM" Name="Output" Kind="OutputPin" />
-                  <Pin Id="Rlajy6UfEqINSqhOoSEu6J" Name="Is Blocking" Kind="OutputPin" />
-                  <Pin Id="StZp04uwMdxQNdk4w09Cbr" Name="Readback Time" Kind="OutputPin" />
-                  <Pin Id="EHzCY28z99oNYUSdYTRBbg" Name="Result Available" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="791,886,86,19" Id="BoFea6lGG08LhvkvusIO1c">
-                  <p:NodeReference LastCategoryFullName="HDE.TooltipWidgets" LastDependency="VL.HDE.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <Choice Kind="ProcessAppFlag" Name="SKImageWidget" />
-                  </p:NodeReference>
-                  <Pin Id="IdwDpGo3o5VOdbCPIYhW2S" Name="Node Context" Kind="InputPin" IsHidden="true" />
-                  <Pin Id="JuJeGopAA2iQDZbexHiPIU" Name="Value" Kind="InputPin" />
-                  <Pin Id="GSKNIZpPSbDL2ld4nRhikd" Name="Paint" Kind="InputPin" />
-                  <Pin Id="Bgy687sMVclP1yMW6Me0qf" Name="Size" Kind="InputPin" DefaultValue="2">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                      <Choice Kind="TypeFlag" Name="Float32" />
-                    </p:TypeAnnotation>
-                  </Pin>
-                  <Pin Id="MdqlsOk0nFYN7kVPWjx33t" Name="Checkerboard" Kind="InputPin" DefaultValue="False">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                      <Choice Kind="TypeFlag" Name="Boolean" />
-                    </p:TypeAnnotation>
-                  </Pin>
-                  <Pin Id="O461sOaiXS9NJfHAWAmlNJ" Name="Output" Kind="StateOutputPin" />
-                </Node>
-                <Pad Id="UFDS3aKAurHOSJUjN3gP3e" Comment="Size" Bounds="847,870,35,15" ShowValueBox="true" isIOBox="true" Value="1">
-                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                    <Choice Kind="TypeFlag" Name="Float32" />
-                  </p:TypeAnnotation>
-                </Pad>
-                <Node Bounds="791,703,99,19" Id="NZ1lAZYaKdHOqVARdPoH1u">
-                  <p:NodeReference LastCategoryFullName="Fuse.Core.HDE" LastDependency="VL.Fuse.HDE.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <Choice Kind="ProcessAppFlag" Name="PreventWhiteFlash" />
-                  </p:NodeReference>
-                  <Pin Id="Ff5KvrA2nk8QJzAOmMqeFC" Name="Node Context" Kind="InputPin" IsHidden="true" />
-                  <Pin Id="GdVnBvS7qazPtmG9GmsjTb" Name="Initial Color" Kind="InputPin" />
-                  <Pin Id="MrIv44BsWX0NRMJyaqFvGD" Name="Image" Kind="InputPin" />
-                  <Pin Id="L1YPwTXr1uTNuR1BH87fPq" Name="Frames To Wait" Kind="InputPin" />
-                  <Pin Id="DvnWkeRhtBPQcOcv9LfMjB" Name="Output" Kind="OutputPin" />
-                  <Pin Id="ArBesp4y9CPL4WIfipU7IX" Name="Enabled" Kind="OutputPin" />
-                </Node>
-                <Pad Id="TCrT3Wdl2mbNM8svu3NGOK" Comment="Frames To Wait" Bounds="887,678,35,15" ShowValueBox="true" isIOBox="true" Value="3">
-                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                    <Choice Kind="TypeFlag" Name="Integer32" />
-                  </p:TypeAnnotation>
-                </Pad>
-                <Node Bounds="818,829,80,19" Id="KxC3Lw8hHqGPv8syHvVhG6">
-                  <p:NodeReference LastCategoryFullName="Graphics.Skia.Paint" LastDependency="VL.Skia.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <Choice Kind="ProcessAppFlag" Name="SetBlendMode" />
-                    <CategoryReference Kind="Category" Name="Paint" NeedsToBeDirectParent="true">
-                      <p:OuterCategoryReference Kind="Category" Name="Skia" NeedsToBeDirectParent="true" />
-                    </CategoryReference>
-                  </p:NodeReference>
-                  <Pin Id="MWrbCFB6ohEOph70Cdsrlk" Name="Node Context" Kind="InputPin" IsHidden="true" />
-                  <Pin Id="GIsrwmUXPkTMwwNKS9bQV3" Name="Input" Kind="InputPin" />
-                  <Pin Id="BqQFLipGQTOM3K7ABS9DVR" Name="Value" Kind="InputPin" DefaultValue="SrcOver">
-                    <p:TypeAnnotation LastCategoryFullName="Graphics.Skia.Unwrapped.Enums" LastDependency="VL.Skia.vl">
-                      <Choice Kind="TypeFlag" Name="SKBlendMode" />
-                    </p:TypeAnnotation>
-                  </Pin>
-                  <Pin Id="IXIYxQGotqEOa45cbvifaF" Name="Output" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="889,734,125,19" Id="UVZB2OnJL0hOAtOzPPGJPB">
-                  <p:NodeReference LastCategoryFullName="Animation" LastDependency="VL.CoreLib.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <Choice Kind="ProcessAppFlag" Name="Damper" />
-                  </p:NodeReference>
-                  <Pin Id="GnBQ8YjiJUvMN2KbroXsIT" Name="Node Context" Kind="InputPin" IsHidden="true" />
-                  <Pin Id="VP16ueDGFzWObYvtSEl9Vx" Name="Clock" Kind="InputPin" />
-                  <Pin Id="INJnoGHNlUSLdpHiETq37x" Name="New Clock" Kind="InputPin" />
-                  <Pin Id="MczFwx3NDYEOJhA31uhElX" Name="Goto Position" Kind="InputPin" />
-                  <Pin Id="UtAQiZS1WIrQQ6lE9qml7s" Name="Filter Time" Kind="InputPin" DefaultValue="0.5">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                      <Choice Kind="TypeFlag" Name="Float32" />
-                    </p:TypeAnnotation>
-                  </Pin>
-                  <Pin Id="C3pCP71iYZzLsp0dBwnrX8" Name="Cyclic" Kind="InputPin" />
-                  <Pin Id="HXFawAEYIfjNgDaq8aVQ35" Name="Jump" Kind="InputPin" />
-                  <Pin Id="JQlrmBnowF7MYLfgfUmN76" Name="Force New Func" Kind="InputPin" />
-                  <Pin Id="MtnG33O0AM8PzLsZODnmBy" Name="Position" Kind="OutputPin" />
-                  <Pin Id="HfIaRv1ZNdkN1AA4V7OZRn" Name="Velocity" Kind="OutputPin" />
-                  <Pin Id="VCnAopQNut1Pje8rxsEyN4" Name="Acceleration" Kind="OutputPin" />
-                  <Pin Id="NPTk1WFlWJULewveZJhMvH" Name="Function" Kind="OutputPin" />
-                  <Pin Id="VQWE1YycvtnPqJFAXaHvKU" Name="Has Changed" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="818,796,45,19" Id="KS5xcbbtomELPIXGVMgiFC">
-                  <p:NodeReference LastCategoryFullName="Graphics.Skia.Paint" LastDependency="VL.Skia.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <Choice Kind="ProcessAppFlag" Name="Fill" />
-                  </p:NodeReference>
-                  <Pin Id="BjNWtYODq0HM8NbF3L7E3g" Name="Node Context" Kind="InputPin" IsHidden="true" />
-                  <Pin Id="Hh8GEIv0QLUMMNBNSpr0WU" Name="Input" Kind="InputPin" />
-                  <Pin Id="FwbfgexUn3wNM4yO3eOQEH" Name="Color" Kind="InputPin" />
-                  <Pin Id="VJgnP7s8EzXNpTvn02Wizp" Name="Shader" Kind="InputPin" />
-                  <Pin Id="BLnj8JmDBbPN0NjNGbsBwm" Name="Output" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="838,764,56,19" Id="VxIXwc2ZjlyLNQBK8DEQ9A">
-                  <p:NodeReference LastCategoryFullName="Color.RGBA" LastDependency="VL.CoreLib.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <Choice Kind="OperationCallFlag" Name="SetAlpha" />
-                    <CategoryReference Kind="ColorRGBAType" Name="RGBA" NeedsToBeDirectParent="true" />
-                  </p:NodeReference>
-                  <Pin Id="VxcP6OotsNhL4uCArzN3Z4" Name="Input" Kind="StateInputPin" />
-                  <Pin Id="RAZUDWNbM6bPRQ8qEKfEgi" Name="Alpha" Kind="InputPin" />
-                  <Pin Id="SC7nlGeHyUFMlBq4RbEY0b" Name="Output" Kind="StateOutputPin" />
-                </Node>
-                <Patch Id="MN35kI0E78zNnoPLJv6rXu" Name="Create" ManuallySortedPins="true" />
-                <Patch Id="CGJ5biHTjUJOepJy6134Rd" Name="Update" ParticipatingElements="Ns5qtyEqMEwPESSPPfsZIk" ManuallySortedPins="true" />
-                <Pad Id="P2I1sEFQ8SwMtZ0YTpvaDq" Comment="Size" Bounds="895,563,35,28" ShowValueBox="true" isIOBox="true" Value="0, 0">
-                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                    <Choice Kind="TypeFlag" Name="Int2" />
-                  </p:TypeAnnotation>
-                </Pad>
-                <Patch Id="JbeIZVt5xP2QQPUUZrdTgp" Name="Dispose" />
-              </Patch>
-            </Node>
-            <Pad Id="ToWkS8A3ExMNoKp9CdB1BZ" Bounds="773,478,154,37" ShowValueBox="true" isIOBox="true" Value="Check if this is needed">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="TypeFlag" Name="String" />
-              </p:TypeAnnotation>
-              <p:ValueBoxSettings>
-                <p:fontsize p:Type="Int32">9</p:fontsize>
-                <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
-              </p:ValueBoxSettings>
-            </Pad>
             <ControlPoint Id="StjQ8pVpZlEOlyBFlMVklS" Bounds="476,460" />
             <ControlPoint Id="IBiARVPaZRMMNusS4mpV6F" Bounds="437,475" />
             <ControlPoint Id="Rs1wRyxcPs4MAVIMqdjKGN" Bounds="565,338" />
@@ -2732,6 +2398,20 @@
               </p:NodeReference>
               <Pin Id="CYYqTU6kyXwLwjeY0K9ocX" Name="Output" Kind="OutputPin" />
             </Node>
+            <Node Bounds="394,610,83,19" Id="RcarpwaL8NqLP7LFIUsRWr">
+              <p:NodeReference LastCategoryFullName="Stride.HDE" LastDependency="VL.Stride.HDE.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <CategoryReference Kind="Category" Name="Stride" />
+                <CategoryReference Kind="Category" Name="HDE" />
+                <Choice Kind="ProcessAppFlag" Name="TextureWidget" />
+              </p:NodeReference>
+              <Pin Id="ToPQiUW6cNpNKG338aJ26w" Name="Node Context" Kind="InputPin" IsHidden="true" />
+              <Pin Id="OrAiXMjmQkRP93tnQ0I6At" Name="Input" Kind="InputPin" />
+              <Pin Id="TqWyCOS9Z5cQV5uNSgvUp3" Name="Widget Size" Kind="InputPin" />
+              <Pin Id="A6CEA2irDVbLXufWsC6bw4" Name="Reset" Kind="InputPin" />
+              <Pin Id="QjniOIqGpTcPMsLFbFAymE" Name="Max Texture Size" Kind="InputPin" />
+              <Pin Id="LMnqJzvjLWJNN3JgNOPJIM" Name="Widget" Kind="OutputPin" />
+            </Node>
           </Canvas>
           <ProcessDefinition Id="CB389l9LlGnNZun1XlfZkA">
             <Fragment Id="Jwa5xxMGP5NMkjAfcitPGr" Patch="HV82N4vkHAiOC0O3CoD4jh" Enabled="true" />
@@ -2739,37 +2419,15 @@
           </ProcessDefinition>
           <Link Id="RaxaiJc1GbnNPMDH39v5LG" Ids="So9tDFXbgvoNfx0orRIKpm,R8Z9VvD2oNgPq0LQIJn8Ja" IsHidden="true" />
           <Link Id="TnIab7ruTJoPoxsCVqFOyR" Ids="NnnoCvs8o2YNr3gAxTL7Yn,NTWZc010qQKQLL8LLMuOi4" IsHidden="true" />
-          <Link Id="OJve2tKxw4AL61ScSxImzo" Ids="VMAAm4iV1i6Nqm4Ke1aiVe,T5dFcH01wmdOPahMYJpSHP" />
-          <Link Id="Fhs8Wc33RRoLoSvVMwkWTD" Ids="ILtvsSKuqRNOXTIjlQARkD,F1b2flF8R3fNNd7yHP3lBP" />
-          <Link Id="SKyJlFOuBPTQPLPUDuh4o7" Ids="U063PN7DOcPOri6Yu4IUff,OPPoa6vSECjNyAb681gD1L" />
-          <Link Id="PV9Esv1CTfbLOOvkz1H22y" Ids="FgI3errNhHtLZlPX6CdeL7,H8Ut25cZNd0OAzZUKjOYuD" />
-          <Link Id="RxkIg66pDhfLZGuhVu46xo" Ids="R8Ze2hQtP2EON0oDSjEsLv,CpjY4rlzU4MOM3nfgVnpD4" IsFeedback="true" />
-          <Link Id="CiuJ4bfJB3lLZ3uzRusdNa" Ids="N5PPaRNbXdSPC02dkB8FJw,CpjY4rlzU4MOM3nfgVnpD4" />
-          <Link Id="ODKWT8M5ueQLS3K7kTmZRM" Ids="LCZT85Po43AQX3ZB2nzNAE,Vnastc2AjGkPYPZKYzwW9T" IsFeedback="true" />
-          <Link Id="ACOKgsCQEIhPODfG83Cvil" Ids="CpjY4rlzU4MOM3nfgVnpD4,Vnastc2AjGkPYPZKYzwW9T" />
-          <Link Id="VkuFCtAFHILN2NMYmP1Py6" Ids="BhMUpPIhwn8PLAunvdJwJn,LCZT85Po43AQX3ZB2nzNAE" />
-          <Link Id="NyFfPe8h52YM6kh43wJ9Oo" Ids="LCZT85Po43AQX3ZB2nzNAE,R8Ze2hQtP2EON0oDSjEsLv" />
-          <Link Id="KSDnDnroYheQNSemh1Ml5T" Ids="Vnastc2AjGkPYPZKYzwW9T,So9tDFXbgvoNfx0orRIKpm" />
-          <Link Id="AE1gskBoUjtL7Hl7ZnkHPd" Ids="P7XDUyYjMvGN3rNwrCIqUR,ESNsVDQTiexOPXuKwVVrVe" />
           <Link Id="ShrvEm5Iw3jP4VzFmsSLML" Ids="P7XDUyYjMvGN3rNwrCIqUR,NnnoCvs8o2YNr3gAxTL7Yn" />
           <Link Id="G0GH9AwJy1qOAlUt6l6NAs" Ids="SqqKWosWjZcLZsxK7jhslr,HPm9LI0ud0mLfq9wlt2Etq" IsHidden="true" />
           <Link Id="LLUbjtGMFnlPI0lhOloyXk" Ids="HPm9LI0ud0mLfq9wlt2Etq,CGNWnCCcTVtOs7XzHPgBwR" />
           <Link Id="BWoX2yMQC2zNWwuATgmRnt" Ids="Ghl8kRDf6V3NpPdSKyh4hm,LbMwpgstKOnP59ItRqntyT" IsHidden="true" />
           <Link Id="GfKjmBHKnXbQAezwVe5JPq" Ids="LbMwpgstKOnP59ItRqntyT,LuJpEqAb4YwLaip9UJRj29" />
-          <Link Id="EcRVNtihwuuLGyMfqy7KLc" Ids="UFDS3aKAurHOSJUjN3gP3e,Bgy687sMVclP1yMW6Me0qf" />
-          <Link Id="T1BtgrH5zPSOkrP7zyA8i5" Ids="DvnWkeRhtBPQcOcv9LfMjB,JuJeGopAA2iQDZbexHiPIU" />
-          <Link Id="PVaT5WaDvQeM7CwpjwBZnn" Ids="TCrT3Wdl2mbNM8svu3NGOK,L1YPwTXr1uTNuR1BH87fPq" />
-          <Link Id="VeO9KyvHGf9PjugQnR3NQQ" Ids="IXIYxQGotqEOa45cbvifaF,GSKNIZpPSbDL2ld4nRhikd" />
-          <Link Id="KveBAWXykElLhzCDCleEW1" Ids="ArBesp4y9CPL4WIfipU7IX,MczFwx3NDYEOJhA31uhElX" />
-          <Link Id="PdwmsWa286jNycvWDPdn65" Ids="MtnG33O0AM8PzLsZODnmBy,RAZUDWNbM6bPRQ8qEKfEgi" />
-          <Link Id="NFq6JgLYNkkOp2CVuvhug3" Ids="SC7nlGeHyUFMlBq4RbEY0b,FwbfgexUn3wNM4yO3eOQEH" />
-          <Link Id="G89sR9jnV3JLhWwdNpLjVK" Ids="BLnj8JmDBbPN0NjNGbsBwm,GIsrwmUXPkTMwwNKS9bQV3" />
-          <Link Id="APtTMwNyBjILZxfBHP28EI" Ids="HjoH2GjkzyJLKmVtV2OSRM,MrIv44BsWX0NRMJyaqFvGD" />
           <Link Id="Rb698pp7b0lN7QZrFbZCpO" Ids="StjQ8pVpZlEOlyBFlMVklS,PtU7CrNiNwbQQNfJLQtiyc" IsHidden="true" />
           <Link Id="TD0pVs88QDsMvPHTtDLlUL" Ids="IlnFOs24GpfMS67dknTdZB,StjQ8pVpZlEOlyBFlMVklS" />
           <Link Id="OKJnXWeLv8APaAtNGcF4Zm" Ids="IBiARVPaZRMMNusS4mpV6F,TcCsjwUGVRDOKxqPCDu17T" IsHidden="true" />
           <Link Id="FCGTaVscHtNLd5dSnNa8PQ" Ids="RsMi6lYP8vON4igTgc6dHd,IBiARVPaZRMMNusS4mpV6F" />
-          <Link Id="Ns5qtyEqMEwPESSPPfsZIk" Ids="P2I1sEFQ8SwMtZ0YTpvaDq,TqmX1EIgnDtQQQypr2L4Sl" />
           <Link Id="VbXK9sB4MphNgBaNolONwc" Ids="Rs1wRyxcPs4MAVIMqdjKGN,Oaq6k7VOVvUQGwHPjwCNql" />
           <Patch Id="HV82N4vkHAiOC0O3CoD4jh" Name="Create" />
           <Patch Id="PxISuq36JqePMwUt7OrWPD" Name="Update" ManuallySortedPins="true">
@@ -2789,7 +2447,8 @@
           <Link Id="GfPmkWyQTAbLf0SsiNpsqQ" Ids="Oaq6k7VOVvUQGwHPjwCNql,CIEoVo5VbXdN6iW18JzkyG" />
           <Link Id="RcoF2nu0iifOCPPNk4Ole0" Ids="CYYqTU6kyXwLwjeY0K9ocX,OhmzKAjYOnsPG40o2NBnE7" />
           <Link Id="QsFKKyWBtcwOYXCag5HsUf" Ids="QEgxW0GnmAOLHMpoUj0jjS,FgInMVO29yiNOFX2wnD7wY" />
-          <Link Id="VNdcdrL97oBLJNXpUSNDA8" Ids="QEgxW0GnmAOLHMpoUj0jjS,Sj63Ns3RwFoLupHcKFmssI" />
+          <Link Id="QdG1rQBKdYFORGJNoe1iRD" Ids="P7XDUyYjMvGN3rNwrCIqUR,OrAiXMjmQkRP93tnQ0I6At" />
+          <Link Id="Oc98NCd33WEL38riw7EaeV" Ids="LMnqJzvjLWJNN3JgNOPJIM,So9tDFXbgvoNfx0orRIKpm" />
         </Patch>
       </Node>
       <!--
@@ -2803,87 +2462,22 @@
         </p:NodeReference>
         <Patch Id="GpXyCEs5VMbP2PoYrGh8q5">
           <Canvas Id="Cf7rdpHg7uoPylkcpRwGgc" CanvasType="Group">
-            <ControlPoint Id="RRwr9BOVmkkOSHmIlBXirn" Bounds="618,422" />
-            <ControlPoint Id="UdnqGSGPFlQMMd1EZW9x9s" Bounds="562,398" />
-            <ControlPoint Id="LVzZaIH6iVON5VpByl5H7V" Bounds="573,740" />
-            <Node Bounds="559,437,91,19" Id="JLLdOqwmKjaORnrtMYi0le">
-              <p:NodeReference LastCategoryFullName="Stride.Textures" LastDependency="VL.Stride.Runtime.vl">
+            <ControlPoint Id="RRwr9BOVmkkOSHmIlBXirn" Bounds="645,440" />
+            <ControlPoint Id="UdnqGSGPFlQMMd1EZW9x9s" Bounds="561,440" />
+            <ControlPoint Id="LVzZaIH6iVON5VpByl5H7V" Bounds="555,641" />
+            <Node Bounds="559,560,83,19" Id="HR3WLQMdSegLpeHnNh7SAx">
+              <p:NodeReference LastCategoryFullName="Stride.HDE" LastDependency="VL.Stride.HDE.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="ProcessAppFlag" Name="TextureToImage" />
+                <CategoryReference Kind="Category" Name="Stride" />
+                <CategoryReference Kind="Category" Name="HDE" />
+                <Choice Kind="ProcessAppFlag" Name="TextureWidget" />
               </p:NodeReference>
-              <Pin Id="N1MrHl2OmdVMauTxLdTI3C" Name="Node Context" Kind="InputPin" IsHidden="true" />
-              <Pin Id="L3JdMWIHHItMqBtK8skJw8" Name="Input" Kind="InputPin" />
-              <Pin Id="LUzIEoFjiGSM9Ebbacq1iQ" Name="Frame Delay" Kind="InputPin" />
-              <Pin Id="T5THYvbqmsNQWL5z2NVbHN" Name="Size" Kind="InputPin" />
-              <Pin Id="D5xPiics3FXPeKnhsDoUPE" Name="New Format" Kind="InputPin" />
-              <Pin Id="KRnoRXthVcKLit3u523cY0" Name="Output" Kind="OutputPin" />
-              <Pin Id="OxjrZTPdQbaOPUHMeFP7FK" Name="Is Blocking" Kind="OutputPin" />
-              <Pin Id="EV5y6DuAikDO3gjHUxjbUB" Name="Readback Time" Kind="OutputPin" />
-              <Pin Id="HQWYREfzWDbLLsfdCPnIUn" Name="Result Available" Kind="OutputPin" />
-            </Node>
-            <Node Bounds="537,529,145,180" Id="SrjPra2s2m8NlXnABEW7qy">
-              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
-                <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
-                <Choice Kind="ApplicationStatefulRegion" Name="If" />
-                <CategoryReference Kind="Category" Name="Primitive" />
-              </p:NodeReference>
-              <Pin Id="QvNcjTCAQSrNQIPIY5lIAB" Name="Condition" Kind="InputPin" />
-              <ControlPoint Id="ClkAgEgjAkpNWcfDhmDz5l" Bounds="574,703" Alignment="Bottom" />
-              <ControlPoint Id="FRxqJHi36bMLLJ1eTJ17mk" Bounds="574,535" Alignment="Top" />
-              <Patch Id="DL17UoICAqwNSC14tBrhhr" ManuallySortedPins="true">
-                <Patch Id="JtUR14U6krdN043iXgKqtN" Name="Create" ManuallySortedPins="true" />
-                <Patch Id="KH03rNiwwyuPjV6HBYCgxk" Name="Then" ManuallySortedPins="true" />
-                <Node Bounds="560,568,82,26" Id="KuH75odBNreMN5OiZMkNq1">
-                  <p:NodeReference LastCategoryFullName="Graphics.Skia.Imaging" LastDependency="VL.Skia.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="Category" Name="Imaging" NeedsToBeDirectParent="true" />
-                    <Choice Kind="OperationCallFlag" Name="TryFromImage" />
-                  </p:NodeReference>
-                  <Pin Id="Be2YUcwpxBMOB7hPZzBftH" Name="Input" Kind="InputPin" />
-                  <Pin Id="DM94P8On0jQPyFL2EABGHi" Name="Discard Higher Bits" Kind="InputPin" />
-                  <Pin Id="TBZpbTwGfhgPd0KmzQNiYF" Name="Result" Kind="OutputPin" />
-                  <Pin Id="B2IYA4EShInOwTZnyf93yi" Name="Image" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="560,610,110,79" Id="GiTXCjwWdDkPWND4UJkthA">
-                  <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
-                    <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
-                    <Choice Kind="ApplicationStatefulRegion" Name="If" />
-                    <CategoryReference Kind="Category" Name="Primitive" />
-                  </p:NodeReference>
-                  <Pin Id="JFlZEzh6pNZPHWwTmTmcMw" Name="Condition" Kind="InputPin" />
-                  <ControlPoint Id="S3O2quxwJsmM5w6Rppey7E" Bounds="574,683" Alignment="Bottom" />
-                  <ControlPoint Id="LsUSjAgO3AWPwWYGbRfrtS" Bounds="574,616" Alignment="Top" />
-                  <Patch Id="BilfBKWrmIyMCVgopS9MCw" ManuallySortedPins="true">
-                    <Patch Id="JKczU4WazBwPeFcId7zMdh" Name="Create" ManuallySortedPins="true" />
-                    <Patch Id="NdcdC4J1AJvMU5aGJe7i2u" Name="Then" ManuallySortedPins="true" />
-                    <Node Bounds="572,641,86,19" Id="VdW14YpkU59OhAfWF5si0x">
-                      <p:NodeReference LastCategoryFullName="HDE.TooltipWidgets" LastDependency="VL.HDE.vl">
-                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                        <Choice Kind="ProcessNode" Name="SKImageWidget" />
-                      </p:NodeReference>
-                      <Pin Id="LB9H5gdVtsIO6FfXio1Q6d" Name="Node Context" Kind="InputPin" IsHidden="true" />
-                      <Pin Id="HO1jlrR9GTOPDQCi7YYSC4" Name="Value" Kind="InputPin" />
-                      <Pin Id="CBhVMrsVhfFQVFcqTCXkCI" Name="Paint" Kind="InputPin" />
-                      <Pin Id="RGmkRQDpOo3MhDccQ5igRL" Name="Size" Kind="InputPin" />
-                      <Pin Id="IQUAOfoj8yzOu6iha8ZQyf" Name="Checkerboard" Kind="InputPin" />
-                      <Pin Id="E7InWp2fxVnNCflZUVfTv6" Name="Output" Kind="StateOutputPin" />
-                    </Node>
-                  </Patch>
-                </Node>
-              </Patch>
-            </Node>
-            <Node Bounds="572,487,76,19" Id="RKwlZFJJNCuPUycSs4V1mA">
-              <p:NodeReference LastCategoryFullName="HDE.TooltipWidgets" LastDependency="VL.HDE.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="ProcessAppFlag" Name="EmptyWidget" />
-              </p:NodeReference>
-              <Pin Id="JMTyfPluRJTMWBDX1u44US" Name="Node Context" Kind="InputPin" IsHidden="true" />
-              <Pin Id="Cat2PowZtKsPAJaRNlfH4t" Name="Default Size" Kind="InputPin" DefaultValue="1, 1">
-                <p:TypeAnnotation LastCategoryFullName="2D" LastDependency="VL.CoreLib.vl">
-                  <Choice Kind="TypeFlag" Name="Vector2" />
-                </p:TypeAnnotation>
-              </Pin>
-              <Pin Id="RO8XoZvQT6kMBrkSb8LbEk" Name="Output" Kind="StateOutputPin" />
+              <Pin Id="Rvgw3zacn8EPzCD3iVRohr" Name="Node Context" Kind="InputPin" IsHidden="true" />
+              <Pin Id="IYIK720UMnKNfamMDlIxYa" Name="Input" Kind="InputPin" />
+              <Pin Id="EzhW37L5TG7L4r4OkZAcwI" Name="Widget Size" Kind="InputPin" />
+              <Pin Id="D4gJiEUIVOMQEoMJnPqAqh" Name="Reset" Kind="InputPin" />
+              <Pin Id="CbzHABM3WWzQVZwGoMpj2o" Name="Max Texture Size" Kind="InputPin" />
+              <Pin Id="BfqlYPxsOLVNMyr5W9IE5U" Name="Widget" Kind="OutputPin" />
             </Node>
           </Canvas>
           <ProcessDefinition Id="LVWUNQ9zdquMN6o57SV521">
@@ -2899,19 +2493,9 @@
             <Pin Id="P1irh9oJaStOdjifQN38qi" Name="Output" Kind="OutputPin" Bounds="862,835" />
           </Patch>
           <Link Id="KfZjB9QnUIlLiO2mNzcT3u" Ids="LVzZaIH6iVON5VpByl5H7V,P1irh9oJaStOdjifQN38qi" IsHidden="true" />
-          <Link Id="Daimag9i9AWLYvlFCI7JpM" Ids="KRnoRXthVcKLit3u523cY0,Be2YUcwpxBMOB7hPZzBftH" />
-          <Link Id="I6uiI2bawSQN5mlZl0LhLi" Ids="HQWYREfzWDbLLsfdCPnIUn,QvNcjTCAQSrNQIPIY5lIAB" />
-          <Link Id="VQ6HKZthaydLHb09h9lFn4" Ids="B2IYA4EShInOwTZnyf93yi,HO1jlrR9GTOPDQCi7YYSC4" />
-          <Link Id="GLNEkxONJHcORXWJdREqC3" Ids="TBZpbTwGfhgPd0KmzQNiYF,JFlZEzh6pNZPHWwTmTmcMw" />
-          <Link Id="KvSMbvyzyAVPodxRv5ntK6" Ids="LsUSjAgO3AWPwWYGbRfrtS,S3O2quxwJsmM5w6Rppey7E" IsFeedback="true" />
-          <Link Id="Fe3PyNdL1rvQCapPI3clQf" Ids="E7InWp2fxVnNCflZUVfTv6,S3O2quxwJsmM5w6Rppey7E" />
-          <Link Id="HG5AgWyky2yMiaDCTBoYNG" Ids="FRxqJHi36bMLLJ1eTJ17mk,ClkAgEgjAkpNWcfDhmDz5l" IsFeedback="true" />
-          <Link Id="Q7RDh4EjRZVMTCCpIBueqv" Ids="S3O2quxwJsmM5w6Rppey7E,ClkAgEgjAkpNWcfDhmDz5l" />
-          <Link Id="K4eEtQGIx2SMT7KAHx1c3u" Ids="RO8XoZvQT6kMBrkSb8LbEk,FRxqJHi36bMLLJ1eTJ17mk" />
-          <Link Id="RZvI6vUt15rLXo7LkEEsei" Ids="FRxqJHi36bMLLJ1eTJ17mk,LsUSjAgO3AWPwWYGbRfrtS" />
-          <Link Id="L2ptNNdW5VTPYwMRWvwCDP" Ids="UdnqGSGPFlQMMd1EZW9x9s,L3JdMWIHHItMqBtK8skJw8" />
-          <Link Id="UvSXalC0t0jQGOZYorDzFA" Ids="RRwr9BOVmkkOSHmIlBXirn,T5THYvbqmsNQWL5z2NVbHN" />
-          <Link Id="Q87tpCNFDljLHf05e1Wv9g" Ids="ClkAgEgjAkpNWcfDhmDz5l,LVzZaIH6iVON5VpByl5H7V" />
+          <Link Id="MEWCLwqoBpuNQYMIqgZufy" Ids="UdnqGSGPFlQMMd1EZW9x9s,IYIK720UMnKNfamMDlIxYa" />
+          <Link Id="EsKHceW4XvvN6V3ix9gKh1" Ids="BfqlYPxsOLVNMyr5W9IE5U,LVzZaIH6iVON5VpByl5H7V" />
+          <Link Id="Vy60sqZewuDM2VSVHsrm6G" Ids="RRwr9BOVmkkOSHmIlBXirn,CbzHABM3WWzQVZwGoMpj2o" />
         </Patch>
       </Node>
       <!--
@@ -3349,187 +2933,6 @@
           <Link Id="IpEdGM3XdfSMWt6YtDFhBH" Ids="EtDFtQtKmixQQevBmZPlym,HIsnoeSm9PFOvvWTzjRY5f" />
           <Link Id="NM7zMkZWQAhPlLJCF8jN50" Ids="Jpg9P5D0S7ANuqGROw1TFX,NHSAYbqCz66LruO9EQN9wP" />
           <Link Id="MWlL8TagiYxP9vCgPeRdzz" Ids="JTzMaxXQiafMONRUmsomCX,Nq5vJ9a6j0yLWMwNjSXN9o" />
-        </Patch>
-      </Node>
-      <!--
-
-    ************************ PreventWhiteFlash (Internal) ************************
-
--->
-      <Node Name="PreventWhiteFlash (Internal)" Bounds="879,641" Id="OIfNu8UpWanO6hTKcJPb8j">
-        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
-          <Choice Kind="ContainerDefinition" Name="Process" />
-        </p:NodeReference>
-        <Patch Id="EHC6mpc6z6aMueEuMGlj1H">
-          <Canvas Id="AVGqokWjhxZMlJQA7GhS7y" CanvasType="Group">
-            <Node Bounds="853,501,105,26" Id="Th7TNRkMfNpPcxCYvzxXnP">
-              <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="ToImage" />
-                <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
-              </p:NodeReference>
-              <Pin Id="QKUmQ4ZwXDgPwowmatOHVw" Name="Input" Kind="StateInputPin" />
-              <Pin Id="KIh90sOggo5Lh7vsEbTUvD" Name="Width" Kind="InputPin" DefaultValue="2">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                  <Choice Kind="TypeFlag" Name="Integer32" />
-                </p:TypeAnnotation>
-              </Pin>
-              <Pin Id="PlRpPVUkp5dLrBJmgD42sp" Name="Height" Kind="InputPin" DefaultValue="2">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                  <Choice Kind="TypeFlag" Name="Integer32" />
-                </p:TypeAnnotation>
-              </Pin>
-              <Pin Id="JXJsJJTmAAmQbTGOugmYqf" Name="Format" Kind="InputPin" DefaultValue="R8G8B8A8">
-                <p:TypeAnnotation LastCategoryFullName="Graphics.Imaging" LastDependency="VL.CoreLib.vl">
-                  <Choice Kind="TypeFlag" Name="PixelFormat" />
-                </p:TypeAnnotation>
-              </Pin>
-              <Pin Id="UmHI4AhpTh4N5Br5GDTDcJ" Name="Is Premultiplied Alpha" Kind="InputPin" />
-              <Pin Id="I4vJuVri4WQLjzMnLAQsfo" Name="Original Format" Kind="InputPin" DefaultValue="">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                  <Choice Kind="TypeFlag" Name="String" />
-                </p:TypeAnnotation>
-              </Pin>
-              <Pin Id="IG6zHqSsJm0MFwk9Fq6Vrp" Name="Result" Kind="OutputPin" />
-            </Node>
-            <Node Bounds="841,388,88,90" Id="I9UPxYAp1g8PEQId5gwhgH">
-              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
-                <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
-                <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
-                <CategoryReference Kind="Category" Name="Primitive" />
-              </p:NodeReference>
-              <Pin Id="AG18SoIj8acOTA8SWdRhmu" Name="Break" Kind="OutputPin" />
-              <ControlPoint Id="Dj3ySfl7vWZNph6q2TeFXO" Bounds="856,394" Alignment="Top" />
-              <ControlPoint Id="H9WGFmKCQ9wMjt5ISNBvaX" Bounds="855,472" Alignment="Bottom" />
-              <Patch Id="UEyGy69a6VRNn26VggFUqQ" ManuallySortedPins="true">
-                <Patch Id="Vv6p1BQraXBMJNcRfL6otk" Name="Create" ManuallySortedPins="true" />
-                <Patch Id="AtOTzckdjsBN88EfdFdaEH" Name="Update" ManuallySortedPins="true" />
-                <Patch Id="JRcaEHG6cE3Me6ioNg4Ijj" Name="Dispose" ManuallySortedPins="true" />
-                <Node Bounds="853,426,64,19" Id="JT01zWK0juQPA4fdyzUgRC">
-                  <p:NodeReference LastCategoryFullName="2D" LastDependency="VL.Skia.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <Choice Kind="OperationCallFlag" Name="ToSKColor (Color)" />
-                  </p:NodeReference>
-                  <Pin Id="VbHBuMF3qW2MBwco2Ezahb" Name="Input" Kind="InputPin" />
-                  <Pin Id="VvO15LKkCzGOU0JC8nbkyX" Name="Output" Kind="OutputPin" />
-                </Node>
-              </Patch>
-            </Node>
-            <Pad Id="E5mt1ZEBRArPOER0BnIZbg" Bounds="855,556" />
-            <Node Bounds="581,474,81,19" Id="S9b0zL3rz1sLns9PGvBCcj">
-              <p:NodeReference LastCategoryFullName="Animation.FrameBased" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="ProcessAppFlag" Name="FrameCounter" />
-                <CategoryReference Kind="Category" Name="FrameBased" NeedsToBeDirectParent="true" />
-              </p:NodeReference>
-              <Pin Id="DH7DqGdfy7jNvJnADWCyms" Name="Node Context" Kind="InputPin" IsHidden="true" />
-              <Pin Id="OsKftRti81gOEY9uCozAxK" Name="Count" Kind="ApplyPin" />
-              <Pin Id="DgURwnrLyvjMggZoLRhZA9" Name="Reset" Kind="ApplyPin" />
-              <Pin Id="FTiz9iEriWHNKTkzPtrt6V" Name="Value" Kind="OutputPin" />
-            </Node>
-            <Node Bounds="581,516,25,19" Id="KyzvwiFlFwzN3sntJ1NjeQ">
-              <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="&gt;=" />
-                <CategoryReference Kind="Category" Name="Math" NeedsToBeDirectParent="true" />
-              </p:NodeReference>
-              <Pin Id="ROpwaqkYZt6PoZ0xsAs3G3" Name="Input" Kind="InputPin" />
-              <Pin Id="U9mq7oGF6q3OPgQWGmZ0xT" Name="Input 2" Kind="InputPin" />
-              <Pin Id="DkHw536yCodOVS6hIQlVAo" Name="Result" Kind="OutputPin" />
-            </Node>
-            <Pad Id="JVSF8s18OwGPhACzlmQ22d" Comment="Count" Bounds="583,414,35,35" ShowValueBox="true" isIOBox="true" Value="True">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="TypeFlag" Name="Boolean" />
-                <FullNameCategoryReference ID="Primitive" />
-              </p:TypeAnnotation>
-              <p:ValueBoxSettings>
-                <p:buttonmode p:Type="String">Toggle</p:buttonmode>
-              </p:ValueBoxSettings>
-            </Pad>
-            <Node Bounds="581,598,45,19" Id="KRekp40mD5eNDjdFy7wfRe">
-              <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="Switch (Boolean)" />
-              </p:NodeReference>
-              <Pin Id="K95W0CmYDkkLbfqYBGC8Qb" Name="Condition" Kind="InputPin" />
-              <Pin Id="QtXRhyzHJ8kL0W56uVAZ8N" Name="Input" Kind="InputPin" />
-              <Pin Id="CgsinGSryf0Mk1F1uboLZK" Name="Input 2" Kind="InputPin" />
-              <Pin Id="Fi2eAceSZQtPh3iGew9DLb" Name="Output" Kind="OutputPin" />
-            </Node>
-            <ControlPoint Id="EWYFydW2AFDNVB3w6tAo9j" Bounds="702,484" />
-            <ControlPoint Id="VurxpLs1USrOClVOBq1d0s" Bounds="661,688" />
-            <ControlPoint Id="SplPculP788NfLHPIftvSP" Bounds="459,556" />
-            <Node Bounds="801,318,25,19" Id="PEQQDH3LGuSMwrleGg1aRV">
-              <p:NodeReference LastCategoryFullName="Collections.Sequence" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="Repeat" />
-                <CategoryReference Kind="MutableInterfaceType" Name="Sequence" NeedsToBeDirectParent="true" />
-              </p:NodeReference>
-              <Pin Id="NSOjvywXjWZNHMjr95b8my" Name="Element" Kind="InputPin" />
-              <Pin Id="QhWGfS19xCgMjSeqiE5D8f" Name="Count" Kind="InputPin" />
-              <Pin Id="GQUTyJt08V1O6GQAyepiMM" Name="Result" Kind="OutputPin" />
-            </Node>
-            <ControlPoint Id="Dupf3uK3aOaOiRvEdHf47h" Bounds="802,267" />
-            <Pad Id="DRRXXQvpdcfNX8lU4VvsXx" Comment="Count" Bounds="845,295,35,15" ShowValueBox="true" isIOBox="true" Value="4">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="TypeFlag" Name="Integer32" />
-              </p:TypeAnnotation>
-            </Pad>
-            <Node Bounds="581,634,82,26" Id="SVILTT89qH4L3GzZtbevjz">
-              <p:NodeReference LastCategoryFullName="Graphics.Skia.Imaging" LastDependency="VL.Skia.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <CategoryReference Kind="Category" Name="Imaging" NeedsToBeDirectParent="true" />
-                <Choice Kind="OperationCallFlag" Name="TryFromImage" />
-              </p:NodeReference>
-              <Pin Id="AUEr5gpnLg9LBHqnGWgTk2" Name="Input" Kind="InputPin" />
-              <Pin Id="T2qcK84ksNZPKZcCoC9d61" Name="Discard Higher Bits" Kind="InputPin" />
-              <Pin Id="Mm8smsnDj3QLxdKA1t99Ml" Name="Result" Kind="OutputPin" />
-              <Pin Id="OQwVARRwQIuPnfWPy7mjfY" Name="Image" Kind="OutputPin" />
-            </Node>
-            <ControlPoint Id="LAlPXp2BNKpObABUaE5Yqh" Bounds="845,617" />
-          </Canvas>
-          <ProcessDefinition Id="FmCOcTb1r5qMXRia7fuigs">
-            <Fragment Id="IzlXBW6a8GaQPbcCvi7YRQ" Patch="UkwkuWLqxBnP8oL98Pug1z" Enabled="true" />
-            <Fragment Id="DpxNa61auiMMWeYKKtAFFP" Patch="MUV4nsGptmOM2qWgbYCm43" Enabled="true" />
-          </ProcessDefinition>
-          <Link Id="Aj4ClZC6TfGMS4UmHMx8Po" Ids="Dj3ySfl7vWZNph6q2TeFXO,VbHBuMF3qW2MBwco2Ezahb" />
-          <Link Id="ELriOSmspFvPXD4HwpyVzj" Ids="VvO15LKkCzGOU0JC8nbkyX,H9WGFmKCQ9wMjt5ISNBvaX" />
-          <Link Id="Gichj3Md7EpO7LjslPjztN" Ids="H9WGFmKCQ9wMjt5ISNBvaX,QKUmQ4ZwXDgPwowmatOHVw" />
-          <Link Id="UvTnVlh8NHRPflfTn76sNt" Ids="IG6zHqSsJm0MFwk9Fq6Vrp,E5mt1ZEBRArPOER0BnIZbg" />
-          <Link Id="O2hDNpu2ybhMKCmC65ckWJ" Ids="E5mt1ZEBRArPOER0BnIZbg,QtXRhyzHJ8kL0W56uVAZ8N" />
-          <Link Id="OFnRFEu4udtNV6Uoa75W8J" Ids="FTiz9iEriWHNKTkzPtrt6V,ROpwaqkYZt6PoZ0xsAs3G3" />
-          <Link Id="UN8VDrx4X8vOQ0Ubo9oxBH" Ids="JVSF8s18OwGPhACzlmQ22d,OsKftRti81gOEY9uCozAxK" />
-          <Link Id="FchA2jExhcqQXmRHT9A2Kf" Ids="DkHw536yCodOVS6hIQlVAo,K95W0CmYDkkLbfqYBGC8Qb" />
-          <Link Id="J505xsHWBVnPw3jE1q8fSd" Ids="EWYFydW2AFDNVB3w6tAo9j,U9mq7oGF6q3OPgQWGmZ0xT" />
-          <Link Id="T4QUEOvDxBwM5CwQ2az7y4" Ids="FTw1Qlmru4dNenkjZryAgD,EWYFydW2AFDNVB3w6tAo9j" IsHidden="true" />
-          <Link Id="KTjrswlevsGN8ZAuG5GexS" Ids="VurxpLs1USrOClVOBq1d0s,E7MC7fhotDjPJWjfZWLrsG" IsHidden="true" />
-          <Link Id="M2vUVIs6TsjP71UwymwFNI" Ids="SplPculP788NfLHPIftvSP,CgsinGSryf0Mk1F1uboLZK" />
-          <Link Id="NAohbHzs6VVOtcgSxzLGYs" Ids="T9foRopOkJiOvLdGcFCMAi,SplPculP788NfLHPIftvSP" IsHidden="true" />
-          <Link Id="AuJbEeupMLZNByDHWoyAQX" Ids="GQUTyJt08V1O6GQAyepiMM,Dj3ySfl7vWZNph6q2TeFXO" />
-          <Link Id="QLyvYLuOmRINTtAn8XXN2i" Ids="Dupf3uK3aOaOiRvEdHf47h,NSOjvywXjWZNHMjr95b8my" />
-          <Link Id="IWs91AdhNW4NOZR4PCNTDi" Ids="TsFYpCObowEMRu0Zx1G0cW,Dupf3uK3aOaOiRvEdHf47h" IsHidden="true" />
-          <Link Id="F9JplYP73KqPHpuiXMAe6y" Ids="DRRXXQvpdcfNX8lU4VvsXx,QhWGfS19xCgMjSeqiE5D8f" />
-          <Link Id="ILnNC5rRStQP0Q4sQkcXvY" Ids="Fi2eAceSZQtPh3iGew9DLb,AUEr5gpnLg9LBHqnGWgTk2" />
-          <Link Id="TVku3n56b2uQD1uIW1tJ2O" Ids="OQwVARRwQIuPnfWPy7mjfY,VurxpLs1USrOClVOBq1d0s" />
-          <Link Id="TU5NnKNe63mNmAPak4vtBY" Ids="DkHw536yCodOVS6hIQlVAo,LAlPXp2BNKpObABUaE5Yqh" />
-          <Link Id="ORWzstdLSPEM4pt2PPP6ez" Ids="LAlPXp2BNKpObABUaE5Yqh,Hi9e2q3goQTM19bXEGN8XD" IsHidden="true" />
-          <Patch Id="UkwkuWLqxBnP8oL98Pug1z" Name="Create" ParticipatingElements="Th7TNRkMfNpPcxCYvzxXnP">
-            <Pin Id="TsFYpCObowEMRu0Zx1G0cW" Name="Initial Color" Kind="InputPin" Bounds="802,266" DefaultValue="0.2, 0.2, 0.2, 1">
-              <p:TypeAnnotation LastCategoryFullName="Color" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="TypeFlag" Name="RGBA" />
-              </p:TypeAnnotation>
-            </Pin>
-          </Patch>
-          <Patch Id="MUV4nsGptmOM2qWgbYCm43" Name="Update">
-            <Pin Id="T9foRopOkJiOvLdGcFCMAi" Name="Image" Kind="InputPin" Bounds="459,556" />
-            <Pin Id="FTw1Qlmru4dNenkjZryAgD" Name="Frames To Wait" Kind="InputPin" Bounds="771,472" DefaultValue="3">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="TypeFlag" Name="Integer32" />
-              </p:TypeAnnotation>
-            </Pin>
-            <Pin Id="E7MC7fhotDjPJWjfZWLrsG" Name="Output" Kind="OutputPin" Bounds="690,751" />
-            <Pin Id="Hi9e2q3goQTM19bXEGN8XD" Name="Enabled" Kind="OutputPin" Bounds="842,639" />
-          </Patch>
         </Patch>
       </Node>
       <!--
@@ -6798,4 +6201,5 @@
   <DocumentDependency Id="MgIss4xR9oYMu3xfKjFFTK" Location="./vl/Fuse.Compute.vl" />
   <NugetDependency Id="SIiQ50t5ZddLwyxrQ12EZg" Location="VL.Stride.TextureFX" Version="2025.7.0-0320-gfcb63b408e" />
   <NugetDependency Id="LufyFN2LfQ8Mo0gjqGWzDF" Location="VL.Fuse" Version="0.0.0" />
+  <NugetDependency Id="V1eVJflN3PHPRjVB0eCHuO" Location="VL.Stride.HDE" Version="0.0.0" />
 </Document>


### PR DESCRIPTION
Instead of downloading from GPU to CPU to again upload on Skia side, this PR switches to the newly introduced `TextureWidget` which uses a shared texture instead.

Note that when you see low framerates in pure overview patches not using any render windows - this is because there's nothing flushing the command queue anymore. That issue is already addressed in latest vvvv build (>= 7.0-0384).