### PR TITLE
fix(compute): tuple3/tuple4 pin typing

### DIFF
--- a/vl/Fuse.Core.vl
+++ b/vl/Fuse.Core.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="LvtmESncQ8vQUvPOE8Lr4A" LanguageVersion="2025.7.1-0144-g5b48859314" Version="0.128">
-  <NugetDependency Id="BguWkaXEMADMOCpL1jti9a" Location="VL.CoreLib" Version="2025.7.1-0144-g5b48859314" />
+<Document xmlns:p="property" xmlns:r="reflection" Id="LvtmESncQ8vQUvPOE8Lr4A" LanguageVersion="2025.7.1-0156-gdf75a792b5" Version="0.128">
+  <NugetDependency Id="BguWkaXEMADMOCpL1jti9a" Location="VL.CoreLib" Version="2025.7.1-0156-gdf75a792b5" />
   <Patch Id="ALpqjXEf369Pnuk64gmWrV">
     <Canvas Id="V8HBoVZNCZmPvIQ0NbkFQ5" DefaultCategory="Fuse" CanvasType="FullCategory">
       <Canvas Id="ABerAU2ISYTOvBfFQi31lN" Name="Math" Position="298,644">
@@ -41510,7 +41510,7 @@
                 <Pin Id="SJ1xAuyQAL5NbWHuQvVRzn" Name="Size" Kind="InputPin" />
                 <Pin Id="R6rMCcFX5HeMlt5TsgCr4V" Name="Render View" Kind="InputPin" />
                 <Pin Id="OhDT3HCprWWNch6OAjdzjg" Name="Format" Kind="InputPin" />
-                <Pin Id="I4iaJveoBNfLxHrAJ2OURJ" Name="View Format" Kind="InputPin" />
+                <Pin Id="Qgw9bo5EMOILkgeYbvOdzf" Name="View Format" Kind="InputPin" />
                 <Pin Id="UN1oUylWAxEMS0LjoRLClg" Name="Color Shared" Kind="InputPin" IsHidden="true" />
                 <Pin Id="Ik3ik578T21MRDP81Df0ym" Name="Depth Format" Kind="InputPin" />
                 <Pin Id="NQOqyJJqnU2POMv6CkhWIH" Name="Depth Shared" Kind="InputPin" IsHidden="true" />
@@ -44842,7 +44842,7 @@
                   <Pin Id="SPyWPtgdElFMgnQYNsIhTD" Name="Array Size" Kind="InputPin" IsHidden="true" />
                   <Pin Id="JEjZks9GIW3OnLpRU0yog6" Name="Mip Levels" Kind="InputPin" IsHidden="true" />
                   <Pin Id="NSkMmlA9psFMcrafkHAvWn" Name="Format" Kind="InputPin" />
-                  <Pin Id="D17OkKa4Vy3OlAAoEkGyUL" Name="View Format" Kind="InputPin" />
+                  <Pin Id="IDfsnQmSBwOP8mvaxY6Z85" Name="View Format" Kind="InputPin" />
                   <Pin Id="JtQDIcx5PsbNp1bJ4MShET" Name="Is Unordered Access" Kind="InputPin" IsHidden="true" />
                   <Pin Id="LIBSO2mYGYDLk7ZKV0sxRL" Name="Is Render Target" Kind="InputPin" IsHidden="true" />
                   <Pin Id="GNH3dXLktyIPYwWv5t3Gbt" Name="Is Depth Stencil" Kind="InputPin" IsHidden="true" />
@@ -45097,7 +45097,7 @@
                   <Pin Id="BithELE9xMnMoK7riRmza9" Name="Array Size" Kind="InputPin" IsHidden="true" />
                   <Pin Id="DKxHig9FjEZQFOD1bbZAUX" Name="Mip Levels" Kind="InputPin" IsHidden="true" />
                   <Pin Id="JnFHYfGUL0dO9iyGXo7hxc" Name="Format" Kind="InputPin" />
-                  <Pin Id="B3dZHtChTukQClObkiY5yN" Name="View Format" Kind="InputPin" />
+                  <Pin Id="OCqLMikAU7zPzrWpC55LXD" Name="View Format" Kind="InputPin" />
                   <Pin Id="SuInlLLwspTMU81OHpnFz4" Name="Is Unordered Access" Kind="InputPin" IsHidden="true" />
                   <Pin Id="FcGsFsL4XVrPbPjVWA3TW4" Name="Is Render Target" Kind="InputPin" IsHidden="true" />
                   <Pin Id="UJXxGZnBXn3QCSyAyHdtHe" Name="Is Depth Stencil" Kind="InputPin" IsHidden="true" />
@@ -45297,7 +45297,7 @@
                   <Pin Id="Gj8Vwzd8doNL6GAJozOw3k" Name="Array Size" Kind="InputPin" IsHidden="true" />
                   <Pin Id="GcbHCtpOfqgNgvVCZ4gMhs" Name="Mip Levels" Kind="InputPin" IsHidden="true" />
                   <Pin Id="M4v9OFRxQpuPnpwO8Xhq73" Name="Format" Kind="InputPin" />
-                  <Pin Id="KMWJLK0eMb4LwsFtn8WIS2" Name="View Format" Kind="InputPin" />
+                  <Pin Id="AFO74cN37iBLG93Z6pmw0R" Name="View Format" Kind="InputPin" />
                   <Pin Id="GzhA2qL18IhOZodoH63Vnv" Name="Is Unordered Access" Kind="InputPin" IsHidden="true" />
                   <Pin Id="MB9LfE7TfpCOft4oEYPNrx" Name="Is Render Target" Kind="InputPin" IsHidden="true" />
                   <Pin Id="GTHximJ5lfvM2cmcXxlUX2" Name="Is Depth Stencil" Kind="InputPin" IsHidden="true" />
@@ -53111,7 +53111,7 @@
                 <Pin Id="F83cIPBnt8SO6AIiEzfHfW" Name="Array Size" Kind="InputPin" />
                 <Pin Id="Nji1vwT7SikMMxc4sFTfMI" Name="Mip Levels" Kind="InputPin" />
                 <Pin Id="JdbH88IfVm6QbKwNtOHvb8" Name="Format" Kind="InputPin" />
-                <Pin Id="UAbrf2GehorOpzzVTz38Ol" Name="View Format" Kind="InputPin" />
+                <Pin Id="D5If81MMwmNM4BoaMZfmqB" Name="View Format" Kind="InputPin" />
                 <Pin Id="AWcdJv9AtH3NPzI8Uc9e8s" Name="Is Unordered Access" Kind="InputPin" />
                 <Pin Id="Ax7XjeKnDeUO5tutvpVPxu" Name="Is Render Target" Kind="InputPin" />
                 <Pin Id="CrwHzvMbHcWP8IefuuD3kS" Name="Is Depth Stencil" Kind="InputPin" />
@@ -97653,7 +97653,7 @@
             </p:NodeReference>
             <Patch Id="OVpSbMWknuPLzI8H359CS4" IsGeneric="true" ExplicitTypeParameters="T1,T2,T3">
               <Canvas Id="QKPOaDIrUfmPAeIEG0CVzl" CanvasType="Group">
-                <ControlPoint Id="LxyMyNHSqLvMMvkS9jhKiZ" Bounds="815,532" />
+                <ControlPoint Id="LxyMyNHSqLvMMvkS9jhKiZ" Bounds="815,521" />
                 <ControlPoint Id="NziJa0kMtAyOv2zpD3iK1T" Bounds="836,585" />
                 <ControlPoint Id="L4SCvpDloYwPjEeXvgakgu" Bounds="815,794" />
                 <Node Bounds="813,734,42,19" Id="Cv6XQ5aXzVhMBBruvX8P7f">
@@ -97913,13 +97913,16 @@
                     <Choice Kind="TypeFlag" Name="ShaderNode" />
                     <p:TypeArguments>
                       <TypeReference>
-                        <Choice Kind="TypeFlag" Name="Tuple2" />
+                        <Choice Kind="TypeFlag" Name="Tuple3" />
                         <p:TypeArguments>
                           <TypeReference>
                             <Choice Kind="TypeFlag" Name="T1" />
                           </TypeReference>
                           <TypeReference>
                             <Choice Kind="TypeFlag" Name="T2" />
+                          </TypeReference>
+                          <TypeReference>
+                            <Choice Kind="TypeFlag" Name="T3" />
                           </TypeReference>
                         </p:TypeArguments>
                       </TypeReference>
@@ -98115,7 +98118,7 @@
                     <Choice Kind="TypeFlag" Name="ShaderNode" />
                     <p:TypeArguments>
                       <TypeReference>
-                        <Choice Kind="TypeFlag" Name="Tuple3" />
+                        <Choice Kind="TypeFlag" Name="Tuple4" />
                         <p:TypeArguments>
                           <TypeReference>
                             <Choice Kind="TypeFlag" Name="T1" />
@@ -98125,6 +98128,9 @@
                           </TypeReference>
                           <TypeReference>
                             <Choice Kind="TypeFlag" Name="T3" />
+                          </TypeReference>
+                          <TypeReference>
+                            <Choice Kind="TypeFlag" Name="T4" />
                           </TypeReference>
                         </p:TypeArguments>
                       </TypeReference>
@@ -98280,13 +98286,19 @@
                     <Choice Kind="TypeFlag" Name="ShaderNode" />
                     <p:TypeArguments>
                       <TypeReference>
-                        <Choice Kind="TypeFlag" Name="Tuple2" />
+                        <Choice Kind="TypeFlag" Name="Tuple4" />
                         <p:TypeArguments>
                           <TypeReference>
                             <Choice Kind="TypeFlag" Name="T1" />
                           </TypeReference>
                           <TypeReference>
                             <Choice Kind="TypeFlag" Name="T2" />
+                          </TypeReference>
+                          <TypeReference>
+                            <Choice Kind="TypeFlag" Name="T3" />
+                          </TypeReference>
+                          <TypeReference>
+                            <Choice Kind="TypeFlag" Name="T4" />
                           </TypeReference>
                         </p:TypeArguments>
                       </TypeReference>
@@ -112675,7 +112687,7 @@
                     <Pin Id="UFbSBVzwWK2OW0bdCDweoW" Name="Clear Color" Kind="InputPin" />
                     <Pin Id="I0BBn6qF91GNkziAXRUSZe" Name="Format" Kind="InputPin" DefaultValue="R16G16B16A16_Float" />
                     <Pin Id="Fy9LPm7ksSpOFb6eKJXIuR" Name="Output" Kind="OutputPin" />
-                    <Pin Id="NigxVH6cvDuQH9vGxWWK7X" Name="Use Dedicated Device" Kind="InputPin" IsHidden="true" />
+                    <Pin Id="M7vo6072SQbQSRCvnkcYU3" Name="Use Dedicated Device" Kind="InputPin" IsHidden="true" />
                   </Node>
                   <Node Bounds="162,183,85,19" Id="LLWcoBDoFN7OQAQObwZRdy">
                     <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
@@ -114868,7 +114880,7 @@
                 <Pin Id="OfHSaG7d3H2LbwW4UImHqv" Name="Size" Kind="InputPin" />
                 <Pin Id="HYKA1PNJqDDP8CD43RW7px" Name="Render View" Kind="InputPin" />
                 <Pin Id="LH5zNOO2MtDQbMk8e5ZDp2" Name="Format" Kind="InputPin" />
-                <Pin Id="T5MfylVVW5XOv4dSL5kir1" Name="View Format" Kind="InputPin" />
+                <Pin Id="I4MmmyoDE8FPx621JacN6Z" Name="View Format" Kind="InputPin" />
                 <Pin Id="QDOTxEz1x4kPAiq3m1AUHf" Name="Color Shared" Kind="InputPin" IsHidden="true" />
                 <Pin Id="IZLKHGdyA15NnEImN12fsC" Name="Depth Format" Kind="InputPin" />
                 <Pin Id="QvKy7dYlEsbLO0ynhK7p8i" Name="Depth Shared" Kind="InputPin" IsHidden="true" />
@@ -124403,7 +124415,7 @@
                   <Pin Id="AuziLsrbHQxOSTEDsXOdiv" Name="Array Size" Kind="InputPin" IsHidden="true" />
                   <Pin Id="Ptw6LlanDPQMK5AAnZX7hT" Name="Mip Levels" Kind="InputPin" IsHidden="true" />
                   <Pin Id="AQ8npjGtiWVQBHDF7waf9B" Name="Format" Kind="InputPin" />
-                  <Pin Id="CkMSj3eDkxyM1S43BQlyQE" Name="View Format" Kind="InputPin" />
+                  <Pin Id="V7yc9gKgFquOrgVrGBmK3R" Name="View Format" Kind="InputPin" />
                   <Pin Id="CUODB78J97wMiZk2ASADBM" Name="Is Unordered Access" Kind="InputPin" IsHidden="true" />
                   <Pin Id="AttP97hMHEnNo9Feh0lIyh" Name="Is Render Target" Kind="InputPin" IsHidden="true" />
                   <Pin Id="SfmosrjKVvKOlGGuiy6hUd" Name="Is Depth Stencil" Kind="InputPin" IsHidden="true" />
@@ -124426,7 +124438,7 @@
                   <Pin Id="L5b9sQBYjICPpvySqSKNZu" Name="Array Size" Kind="InputPin" IsHidden="true" />
                   <Pin Id="I3fE4WKWCMhLyMl3p8nFnZ" Name="Mip Levels" Kind="InputPin" IsHidden="true" />
                   <Pin Id="HkVgQWCFGg6NsFDk6rvRgD" Name="Format" Kind="InputPin" />
-                  <Pin Id="JjBCMc5cuFpLrA8LIPqLqB" Name="View Format" Kind="InputPin" />
+                  <Pin Id="EPUDMSwoYQGL8hChE997h8" Name="View Format" Kind="InputPin" />
                   <Pin Id="TMUxd9YAgl2Pp5oictL2vw" Name="Is Unordered Access" Kind="InputPin" IsHidden="true" />
                   <Pin Id="Fcua1UiygKJLhBOil6n5j4" Name="Is Render Target" Kind="InputPin" IsHidden="true" />
                   <Pin Id="LhUCgxE8rBcLCa5XPjh1Om" Name="Is Depth Stencil" Kind="InputPin" IsHidden="true" />
@@ -125731,7 +125743,7 @@
                   <Pin Id="UBD7GR4crhgNbvpuVm3cxd" Name="Array Size" Kind="InputPin" IsHidden="true" />
                   <Pin Id="NxrG8714zBVNQuJVXn2fJf" Name="Mip Levels" Kind="InputPin" IsHidden="true" />
                   <Pin Id="FM9myjxvPuqNagwaavBoBB" Name="Format" Kind="InputPin" />
-                  <Pin Id="CFQ8ISkx9ooNqqyTO5TmcB" Name="View Format" Kind="InputPin" />
+                  <Pin Id="Sbw31Le9zp4OJTfv9uymHZ" Name="View Format" Kind="InputPin" />
                   <Pin Id="RPsscDcdCHSMPX1fDnhZS0" Name="Is Unordered Access" Kind="InputPin" IsHidden="true" />
                   <Pin Id="RSHnT7vZfLZMQ5FFIhQQuK" Name="Is Render Target" Kind="InputPin" IsHidden="true" />
                   <Pin Id="GGokrOPQtEwPvN9NfQQDu9" Name="Is Depth Stencil" Kind="InputPin" IsHidden="true" />
@@ -125945,7 +125957,7 @@
                   <Pin Id="FXe29S1ynD1MLxzV8aBFGM" Name="Array Size" Kind="InputPin" IsHidden="true" />
                   <Pin Id="KYsYZTlliTkOyivf7cMVRp" Name="Mip Levels" Kind="InputPin" IsHidden="true" />
                   <Pin Id="Op5i04R7BpZP3bLxTweRZ8" Name="Format" Kind="InputPin" />
-                  <Pin Id="PlIpw4YWUjpLxGJAOITX4c" Name="View Format" Kind="InputPin" />
+                  <Pin Id="UmC0xY7P2UeNbFgYq6jGcS" Name="View Format" Kind="InputPin" />
                   <Pin Id="Mp5kMEJIoohMu5lnAliVwf" Name="Is Unordered Access" Kind="InputPin" IsHidden="true" />
                   <Pin Id="V1wJHgYEvs8PNSgavyL66I" Name="Is Render Target" Kind="InputPin" IsHidden="true" />
                   <Pin Id="VHdmUca2Lj2PKDC8FMc6G7" Name="Is Depth Stencil" Kind="InputPin" IsHidden="true" />
@@ -126117,7 +126129,7 @@
                   <Pin Id="HL2FAtbgdBAOBcvrhYIvH0" Name="Array Size" Kind="InputPin" IsHidden="true" />
                   <Pin Id="GBnHdsk5GrUMKYq0qi35GZ" Name="Mip Levels" Kind="InputPin" IsHidden="true" />
                   <Pin Id="DWGBlhiUPgrOaWxcLmKl1B" Name="Format" Kind="InputPin" />
-                  <Pin Id="MxtlMC8lwC0QMURKtkDS1t" Name="View Format" Kind="InputPin" />
+                  <Pin Id="D699l6sRCjHLONReAPl8b5" Name="View Format" Kind="InputPin" />
                   <Pin Id="VzrMNpAx6kXOxgiIjKzZzO" Name="Is Unordered Access" Kind="InputPin" IsHidden="true" />
                   <Pin Id="AhRsT8AVI4BNhOAAnb16ed" Name="Is Render Target" Kind="InputPin" IsHidden="true" />
                   <Pin Id="PLvpW7MUbEgOBnzNx57SPa" Name="Is Depth Stencil" Kind="InputPin" IsHidden="true" />
@@ -126503,7 +126515,7 @@
                   <Pin Id="MuAPkYU2JMnQIo9VmmwKp0" Name="Array Size" Kind="InputPin" IsHidden="true" />
                   <Pin Id="QuCoIiUKxoiMoiGLkXLrBx" Name="Mip Levels" Kind="InputPin" IsHidden="true" />
                   <Pin Id="V3QoZy73KuCOVIXC4Lhw1i" Name="Format" Kind="InputPin" />
-                  <Pin Id="TuVE036OJ9KPhVrlORQ5D2" Name="View Format" Kind="InputPin" />
+                  <Pin Id="V1HvxpQEeJiLPPFI6bpsi4" Name="View Format" Kind="InputPin" />
                   <Pin Id="Lzcy82VATKHLF880vlX5Cz" Name="Is Unordered Access" Kind="InputPin" IsHidden="true" />
                   <Pin Id="HX8eW2vNvFRPzzgkpK0xuc" Name="Is Render Target" Kind="InputPin" IsHidden="true" />
                   <Pin Id="G1iZvhXLknHPJzgL1zxAEg" Name="Is Depth Stencil" Kind="InputPin" IsHidden="true" />
@@ -126754,7 +126766,7 @@
                   <Pin Id="C34zxE7agfqNLtT0dw5DZ8" Name="Array Size" Kind="InputPin" IsHidden="true" />
                   <Pin Id="JY5fiilv94rLXLUl2Bl9VK" Name="Mip Levels" Kind="InputPin" IsHidden="true" />
                   <Pin Id="Ki5JQeyY4eKPvRPWY9Atnq" Name="Format" Kind="InputPin" />
-                  <Pin Id="SCU0xMo6GLOQaLRY2gyiMN" Name="View Format" Kind="InputPin" />
+                  <Pin Id="HmCTSEKIs4qOcCGcmKjUqU" Name="View Format" Kind="InputPin" />
                   <Pin Id="OBS97abtlBnMYN98qDkka7" Name="Is Unordered Access" Kind="InputPin" IsHidden="true" />
                   <Pin Id="SkFnT96vj90OTrRK3Socli" Name="Is Render Target" Kind="InputPin" IsHidden="true" />
                   <Pin Id="IpdfB0wN3fWPbupR8A54V9" Name="Is Depth Stencil" Kind="InputPin" IsHidden="true" />
@@ -126854,7 +126866,7 @@
                   <Pin Id="Raba01Gg4XVOSIKMUS3wDi" Name="Array Size" Kind="InputPin" IsHidden="true" />
                   <Pin Id="PuY91VWXkpBM7yA5iJ14Oi" Name="Mip Levels" Kind="InputPin" IsHidden="true" />
                   <Pin Id="TSTiJa1N4veOKzr05xwsyb" Name="Format" Kind="InputPin" />
-                  <Pin Id="Ui55MyFcWBAPWybL1jnkfe" Name="View Format" Kind="InputPin" />
+                  <Pin Id="SVWKuBI96u9QU43MfZDYfa" Name="View Format" Kind="InputPin" />
                   <Pin Id="QR9BeQz5HobOrZNBYW7HuB" Name="Is Unordered Access" Kind="InputPin" IsHidden="true" />
                   <Pin Id="L13DfawAThAMnYWa4qe5N5" Name="Is Render Target" Kind="InputPin" IsHidden="true" />
                   <Pin Id="Jh1Q4WYcb5rPYZ62uXtfiH" Name="Is Depth Stencil" Kind="InputPin" IsHidden="true" />
@@ -127101,7 +127113,7 @@
                   <Pin Id="BmfBMpWGJrwMDCm0Ef2BhG" Name="Array Size" Kind="InputPin" IsHidden="true" />
                   <Pin Id="TRysy3fRUpBQOsoq0vDzd9" Name="Mip Levels" Kind="InputPin" IsHidden="true" />
                   <Pin Id="Nh5AvlcU3JCOgAzgdaXRgS" Name="Format" Kind="InputPin" />
-                  <Pin Id="QuURjSylM6RQAdUthOT7UM" Name="View Format" Kind="InputPin" />
+                  <Pin Id="StouzqeT0PQM7UdCDWltzp" Name="View Format" Kind="InputPin" />
                   <Pin Id="Nf0s2D6TKtNQXOVHmEWJui" Name="Is Unordered Access" Kind="InputPin" IsHidden="true" />
                   <Pin Id="BaJQvmLZLVcN0piVxCWRO9" Name="Is Render Target" Kind="InputPin" IsHidden="true" />
                   <Pin Id="C2BlKh3AtqdLT36zWtNo0y" Name="Is Depth Stencil" Kind="InputPin" IsHidden="true" />
@@ -127456,7 +127468,7 @@
                   <Pin Id="NBx5JiF2hjpOHoYHdGqBqx" Name="Array Size" Kind="InputPin" IsHidden="true" />
                   <Pin Id="BS1Qnjj4KFfLqSgA2M8ILq" Name="Mip Levels" Kind="InputPin" IsHidden="true" />
                   <Pin Id="RqUYZ11xP4WOy5mpOAbkcp" Name="Format" Kind="InputPin" />
-                  <Pin Id="Jtb6DMkrRgeM0ZohBTDG8m" Name="View Format" Kind="InputPin" />
+                  <Pin Id="JmvDasbNuDJMtCBwvfEAC3" Name="View Format" Kind="InputPin" />
                   <Pin Id="M38QoTVo5PWNXOjeEJjXHe" Name="Is Unordered Access" Kind="InputPin" IsHidden="true" />
                   <Pin Id="RuA4oDJI1WzMJrMV7cB3K7" Name="Is Render Target" Kind="InputPin" IsHidden="true" />
                   <Pin Id="No0MEUQk5YwQEIOnKSDuep" Name="Is Depth Stencil" Kind="InputPin" IsHidden="true" />
@@ -127784,7 +127796,7 @@
                   <Pin Id="US571APeX2dO3lmxFHvT3h" Name="Array Size" Kind="InputPin" IsHidden="true" />
                   <Pin Id="U5df0KnanYBMFARWQeurlE" Name="Mip Levels" Kind="InputPin" IsHidden="true" />
                   <Pin Id="NxBNUGfXvW5PtigEHjcTrs" Name="Format" Kind="InputPin" />
-                  <Pin Id="EeyjODxE5LxNeDqdaLrf2O" Name="View Format" Kind="InputPin" />
+                  <Pin Id="EK6RwXFhQZQNtvXJ9S4HQ1" Name="View Format" Kind="InputPin" />
                   <Pin Id="AiIMCPMVadaOE6tCh4fkLD" Name="Is Unordered Access" Kind="InputPin" IsHidden="true" />
                   <Pin Id="UrANOwaEjh3NzZLpj1w78L" Name="Is Render Target" Kind="InputPin" IsHidden="true" />
                   <Pin Id="FKr9PtlHv1DQSdzXyJKHu4" Name="Is Depth Stencil" Kind="InputPin" IsHidden="true" />
@@ -128564,7 +128576,7 @@
                   <Pin Id="GEXkrIxQYruNBIze9zp6Qi" Name="Array Size" Kind="InputPin" IsHidden="true" />
                   <Pin Id="LnCsTGSosHMLMK1vjQKBXk" Name="Mip Levels" Kind="InputPin" IsHidden="true" />
                   <Pin Id="R202L5ZZBHmMhfDfLKgpBy" Name="Format" Kind="InputPin" />
-                  <Pin Id="TwLvJdzIaHhLBy1dAaZ9Rk" Name="View Format" Kind="InputPin" />
+                  <Pin Id="NY4eEuTDnqrQJ5BTrUoyGy" Name="View Format" Kind="InputPin" />
                   <Pin Id="Nx8TrifYHMXN1QTi1fjoU3" Name="Is Unordered Access" Kind="InputPin" IsHidden="true" />
                   <Pin Id="VoTG1N6MXEaLao7WKaEGia" Name="Is Render Target" Kind="InputPin" IsHidden="true" />
                   <Pin Id="LYcxCUF33uxMkIIHcvIr4o" Name="Is Depth Stencil" Kind="InputPin" IsHidden="true" />
@@ -128975,7 +128987,7 @@
                   <Pin Id="CDCxySfVxCHNyIbDXjLvXI" Name="Array Size" Kind="InputPin" IsHidden="true" />
                   <Pin Id="LNmb5fMYR2SPj4zdXNSZy5" Name="Mip Levels" Kind="InputPin" IsHidden="true" />
                   <Pin Id="C0zIeHFOEwVPPg3ZTSFZ8T" Name="Format" Kind="InputPin" />
-                  <Pin Id="UBQLeO3yMD5PrzFmdQEnh3" Name="View Format" Kind="InputPin" />
+                  <Pin Id="C3fxTwuwNvOO3I6zNsDgCH" Name="View Format" Kind="InputPin" />
                   <Pin Id="Rg21TlVlZU9LTudtjcHOH3" Name="Is Unordered Access" Kind="InputPin" IsHidden="true" />
                   <Pin Id="HBJHR6mTkSONQ6sfVC84V5" Name="Is Render Target" Kind="InputPin" IsHidden="true" />
                   <Pin Id="KCljwbHj3UYMi1ogeT4Ony" Name="Is Depth Stencil" Kind="InputPin" IsHidden="true" />
@@ -129365,7 +129377,7 @@
                   <Pin Id="M7pHSwzXM0PNifRQCGc7D4" Name="Array Size" Kind="InputPin" IsHidden="true" />
                   <Pin Id="RpbXcMEvQmNL6byzGrgBEh" Name="Mip Levels" Kind="InputPin" IsHidden="true" />
                   <Pin Id="FZwdvTFmKdfNk4PQaZJPOm" Name="Format" Kind="InputPin" />
-                  <Pin Id="UeHkJls0JSCMXhyvQojy4I" Name="View Format" Kind="InputPin" />
+                  <Pin Id="NazPlpNPAV8OrKEHK7DkaP" Name="View Format" Kind="InputPin" />
                   <Pin Id="CsNbjPsD7mmMrRMAMIUwty" Name="Is Unordered Access" Kind="InputPin" IsHidden="true" />
                   <Pin Id="JPqxjrdQrmxLjQcCje59Wj" Name="Is Render Target" Kind="InputPin" IsHidden="true" />
                   <Pin Id="OVjHSuH0rW8MjbyeP8zrLS" Name="Is Depth Stencil" Kind="InputPin" IsHidden="true" />
@@ -129888,7 +129900,7 @@
                   <Pin Id="Iw6LmMnh6zjMakhRrY8UBG" Name="Array Size" Kind="InputPin" IsHidden="true" />
                   <Pin Id="VLZVxaLqjonOoezsMA8H6Y" Name="Mip Levels" Kind="InputPin" IsHidden="true" />
                   <Pin Id="Jd0epkaHOxILof0Zg1EIpq" Name="Format" Kind="InputPin" />
-                  <Pin Id="N7LykM0X8qfPBCbvu5ViE8" Name="View Format" Kind="InputPin" />
+                  <Pin Id="P8JZPUqOqj8PQ57sORc8l0" Name="View Format" Kind="InputPin" />
                   <Pin Id="PCSZLWl8hPwNBrr67ohuM8" Name="Is Unordered Access" Kind="InputPin" IsHidden="true" />
                   <Pin Id="NyNNnSLHkVuOL1PbnXCCS8" Name="Is Render Target" Kind="InputPin" IsHidden="true" />
                   <Pin Id="JA9eSJV3CNdNN4SCkDW1KR" Name="Is Depth Stencil" Kind="InputPin" IsHidden="true" />
@@ -130373,7 +130385,7 @@
                   <Pin Id="VvI8t28qetAPe1iCUTOxPY" Name="Array Size" Kind="InputPin" IsHidden="true" />
                   <Pin Id="ULb98hW40ezP0m9AatYEtF" Name="Mip Levels" Kind="InputPin" IsHidden="true" />
                   <Pin Id="MHopROoLfO7PFBkC8Y1Mcp" Name="Format" Kind="InputPin" />
-                  <Pin Id="RJ134RjRsOsL5cNCE5EsYR" Name="View Format" Kind="InputPin" />
+                  <Pin Id="NHTL9OyJW6QM6NneYbzqkm" Name="View Format" Kind="InputPin" />
                   <Pin Id="Rr3eNCfw7guODsdEnQzOXj" Name="Is Unordered Access" Kind="InputPin" IsHidden="true" />
                   <Pin Id="LZXgfyTbyK4LfsnlTNnwJ7" Name="Is Render Target" Kind="InputPin" IsHidden="true" />
                   <Pin Id="GA4HTjT5ZOzLRSXlCha8Oe" Name="Is Depth Stencil" Kind="InputPin" IsHidden="true" />
@@ -130789,7 +130801,7 @@
                   <Pin Id="S7scXLqf9uoLTQ6BwOa9OO" Name="Array Size" Kind="InputPin" IsHidden="true" />
                   <Pin Id="FWpqiqYhUViLnCZ55IGDXl" Name="Mip Levels" Kind="InputPin" IsHidden="true" />
                   <Pin Id="CpKrFjKTTCWPgPK6rxrRTD" Name="Format" Kind="InputPin" />
-                  <Pin Id="PKREXF1Rw0OLuClLUYTJMy" Name="View Format" Kind="InputPin" />
+                  <Pin Id="KnBPEN0gxmoOWQzee65Ii3" Name="View Format" Kind="InputPin" />
                   <Pin Id="BSE57o4obSGLdYgWjf7ASJ" Name="Is Unordered Access" Kind="InputPin" IsHidden="true" />
                   <Pin Id="U1A7923x4axP2wfiApOnOv" Name="Is Render Target" Kind="InputPin" IsHidden="true" />
                   <Pin Id="OjkzGaCsPa8LYtTBj3AqbQ" Name="Is Depth Stencil" Kind="InputPin" IsHidden="true" />
@@ -133177,7 +133189,7 @@
                   <Pin Id="DotrNraspthM5KA7Rw8hD7" Name="Array Size" Kind="InputPin" IsHidden="true" />
                   <Pin Id="MfpGdGH9QpXNBNPekDDqIH" Name="Mip Levels" Kind="InputPin" IsHidden="true" />
                   <Pin Id="L3t12t6MuQIMZVYC5acqOG" Name="Format" Kind="InputPin" />
-                  <Pin Id="ArbugrCErIELNsHyqoLqQL" Name="View Format" Kind="InputPin" />
+                  <Pin Id="CF04gpWBeKuMM4cSM0krvm" Name="View Format" Kind="InputPin" />
                   <Pin Id="BzC3NFUastpNGjCx68G5yw" Name="Is Unordered Access" Kind="InputPin" IsHidden="true" />
                   <Pin Id="I5M13qGlQ9ONfELbLriM6p" Name="Is Render Target" Kind="InputPin" IsHidden="true" />
                   <Pin Id="Bt1uQgtZKZRMfiWlftEIzO" Name="Is Depth Stencil" Kind="InputPin" IsHidden="true" />
@@ -133280,7 +133292,7 @@
                   <Pin Id="URreln6ZuSDNMXnyBUlRVD" Name="Array Size" Kind="InputPin" IsHidden="true" />
                   <Pin Id="RmQnSzTNY3mL1JG4BDB6iU" Name="Mip Levels" Kind="InputPin" IsHidden="true" />
                   <Pin Id="Ag7RBuS2ztkMrbNFLqVVdL" Name="Format" Kind="InputPin" />
-                  <Pin Id="Erf31kPI8q7MXY2PYAp8mk" Name="View Format" Kind="InputPin" />
+                  <Pin Id="RSn6Q926AeONNawuGOyL8S" Name="View Format" Kind="InputPin" />
                   <Pin Id="Qbyx2G4KSCZOhtSI107fPz" Name="Is Unordered Access" Kind="InputPin" IsHidden="true" />
                   <Pin Id="OrwZL420qjkLfkTRhFWSq5" Name="Is Render Target" Kind="InputPin" IsHidden="true" />
                   <Pin Id="SsWDA4irtaGQSYgiqnnGe9" Name="Is Depth Stencil" Kind="InputPin" IsHidden="true" />
@@ -133657,7 +133669,7 @@
                   <Pin Id="BSC0q9RzFcUO66HYJUbgfO" Name="Array Size" Kind="InputPin" IsHidden="true" />
                   <Pin Id="Rejisqy2N5VMjr4jXVK83w" Name="Mip Levels" Kind="InputPin" IsHidden="true" />
                   <Pin Id="FNyV3CyvaqFNxNEZj7y0uO" Name="Format" Kind="InputPin" />
-                  <Pin Id="GaRbkZ0ERKYPG9EOzJa2ke" Name="View Format" Kind="InputPin" />
+                  <Pin Id="OMTqaVhM2YOMntrBVRDs0L" Name="View Format" Kind="InputPin" />
                   <Pin Id="SLopt0VNkvoLzT7R7D3MJe" Name="Is Unordered Access" Kind="InputPin" IsHidden="true" />
                   <Pin Id="EQnRneUCM7jP4q3IJp2vQC" Name="Is Render Target" Kind="InputPin" IsHidden="true" />
                   <Pin Id="OU7euc04tASMAwzegFeUcs" Name="Is Depth Stencil" Kind="InputPin" IsHidden="true" />
@@ -133760,7 +133772,7 @@
                   <Pin Id="EgOfrYDnC11MDviq9JSfo2" Name="Array Size" Kind="InputPin" IsHidden="true" />
                   <Pin Id="Puz46rYGql3NXpcGpiIp8S" Name="Mip Levels" Kind="InputPin" IsHidden="true" />
                   <Pin Id="C3Ue00yhj6dQRXtAQWzb2x" Name="Format" Kind="InputPin" />
-                  <Pin Id="Tqr2iBGoDkHQQqXxbed4te" Name="View Format" Kind="InputPin" />
+                  <Pin Id="TYlCPVCvCBzMidq0QDXQS8" Name="View Format" Kind="InputPin" />
                   <Pin Id="Ubr74dxoLipPwAulqIJdUb" Name="Is Unordered Access" Kind="InputPin" IsHidden="true" />
                   <Pin Id="FMOArfN7aIRLc3rfMwkXgX" Name="Is Render Target" Kind="InputPin" IsHidden="true" />
                   <Pin Id="LUKNZLT9vYaL4InXKeVLJu" Name="Is Depth Stencil" Kind="InputPin" IsHidden="true" />
@@ -137732,7 +137744,7 @@
                 <Pin Id="BrSnzrFPTNaPRvYwoCL1nt" Name="Size" Kind="InputPin" />
                 <Pin Id="Jo6EbfTvI8PLYJESUuMV8H" Name="Render View" Kind="InputPin" />
                 <Pin Id="SadQimHuXNHPBhhD4Pj6zU" Name="Format" Kind="InputPin" />
-                <Pin Id="L7UaUSVkctELxKWsHhjGpg" Name="View Format" Kind="InputPin" />
+                <Pin Id="TbNg11zPK9EOYyZPtuRgnp" Name="View Format" Kind="InputPin" />
                 <Pin Id="O8LhIvJcP8sOUwasT3aHwK" Name="Color Shared" Kind="InputPin" />
                 <Pin Id="ASdU49ndpXvMxEdqdi41hk" Name="Depth Format" Kind="InputPin" />
                 <Pin Id="MOFJ4UKYQyRMcNCDo139x9" Name="Depth Shared" Kind="InputPin" />
@@ -143705,7 +143717,7 @@
                 <Pin Id="L4RpevtLVmnMbM21ENJzcq" Name="Size" Kind="InputPin" />
                 <Pin Id="NCMYPjzZONcN7BDQQBlD1Y" Name="Render View" Kind="InputPin" />
                 <Pin Id="JhKJv7DCq4VLcAwd0s6mrZ" Name="Format" Kind="InputPin" />
-                <Pin Id="E3TJqJhMiE9P4jYW1fXJQj" Name="View Format" Kind="InputPin" />
+                <Pin Id="CZux6X4OeGwMY4u19Q6x9n" Name="View Format" Kind="InputPin" />
                 <Pin Id="EXK8g1WINz7OX3zcg0ec4y" Name="Color Shared" Kind="InputPin" />
                 <Pin Id="QKANgkULkgOOmyvV0QaBZg" Name="Depth Format" Kind="InputPin" />
                 <Pin Id="SvxTQfciEcYMxH31OWV7Rl" Name="Depth Shared" Kind="InputPin" />
@@ -150994,19 +151006,19 @@
       </Pin>
     </Patch>
   </Patch>
-  <NugetDependency Id="OqJiKCqTIL5O0sN2cXh4YB" Location="VL.Stride" Version="2025.7.1-0144-g5b48859314" />
+  <NugetDependency Id="OqJiKCqTIL5O0sN2cXh4YB" Location="VL.Stride" Version="2025.7.1-0156-gdf75a792b5" />
   <PlatformDependency Id="QD83y6RKYq7OhN3v5WJxtB" Location="mscorlib" />
   <PlatformDependency Id="CCpxO5Bu7DbO7jV0mp1f40" Location="Stride.Graphics.dll" />
   <PlatformDependency Id="V2UtZ1bXsztMkuT3SdP88C" Location="Stride.Rendering.dll" />
   <PlatformDependency Id="DNahkKWwesLMKRTAYg4s96" Location="VL.Stride.Runtime.dll" />
-  <NugetDependency Id="LxLuvn1orjzNwMFxgIbE86" Location="VL.Stride.Runtime" Version="2025.7.1-0144-g5b48859314" />
+  <NugetDependency Id="LxLuvn1orjzNwMFxgIbE86" Location="VL.Stride.Runtime" Version="2025.7.1-0156-gdf75a792b5" />
   <PlatformDependency Id="F8tjKXdZVX9MWeXufVhLDe" Location="../lib/net6.0/Fuse.dll" IsForward="true" />
   <DocumentDependency Id="HSLcakGjsNmOnfDhEdy9Rp" Location="./Fuse.Core.vl" />
   <NugetDependency Id="JXh7p50Pyt1PeDltdklsnT" Location="VL.Fuse" Version="0.0.0" />
   <DocumentDependency Id="K4yHVnm6rp8PP6DKHgadWd" Location="./Fuse.Domain.vl" />
   <PlatformDependency Id="GgBxCjfYclXM3KYnqNsyvF" Location="C:/Users/Christian/AppData/Local/vvvv/_vvvv/vvvv_gamma_2022.5.0-0485-g8f46e4a34a/Stride.dll" />
   <PlatformDependency Id="UwYGnXkcvqdOZoh5qFDs6G" Location="C:/Users/Christian/AppData/Local/vvvv/_vvvv/vvvv_gamma_2022.5.0-0485-g8f46e4a34a/Stride.Graphics.dll" />
-  <NugetDependency Id="RkSdgvMvNNCMQNMGMqlb8t" Location="VL.Skia" Version="2025.7.1-0144-g5b48859314" />
-  <NugetDependency Id="B92aA7i1PIIPMqUkLKUyen" Location="VL.Stride.TextureFX" Version="2025.7.1-0144-g5b48859314" />
+  <NugetDependency Id="RkSdgvMvNNCMQNMGMqlb8t" Location="VL.Skia" Version="2025.7.1-0156-gdf75a792b5" />
+  <NugetDependency Id="B92aA7i1PIIPMqUkLKUyen" Location="VL.Stride.TextureFX" Version="2025.7.1-0156-gdf75a792b5" />
   <PlatformDependency Id="JMZtqfx5TCaLo4idNlZOUz" Location="C:/Users/Christian/development/vl/lib/net6.0/Fuse.dll" />
 </Document>


### PR DESCRIPTION
## Description

Tuple3/Tuple4 Split had Tuple2 as input type
Tuple4 Join had Tuple3 as output type

## Change Type

<!-- Check all that apply -->

- [ ] New shader node
- [ ] New SDSL function
- [ ] Shader modification
- [ ] Core engine change (C#)
- [ ] Help/documentation
- [x ] Bug fix
- [ ] Performance improvement
- [ ] Refactoring

## Affected Domains

<!-- Check all that apply -->

- [ ] Noise
- [ ] SDF (Signed Distance Fields)
- [x ] Compute
- [ ] Domain (Raymarching)
- [ ] Color
- [ ] Transform
- [ ] Texture
- [ ] Geometry
- [ ] Fluid
- [ ] Other: <!-- specify -->

## Breaking Changes

<!-- Check all that apply, or None -->

- [ ] None
- [ ] API changes (C# method signatures)
- [ ] Shader signature changes (SDSL)
- [x ] VL node changes (pins added/removed/renamed)
- [ ] Behavior changes (same inputs, different outputs)

### Migration Guide

Since these nodes don't work as expected at all without the fix I'm assuming they have not been used until now.

## Testing

<!-- Check all that apply -->

- [ ] Tested with existing help patches
- [ ] New help patch added
- [ ] Existing help patch updated
- [x ] Manual GPU output verification
- [ ] Performance tested

### Test Details

I am actively using the nodes in a compute system i am building, its working as expected...

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->

## Screenshots/Videos

<!-- If visual changes, add before/after screenshots or videos -->

## Checklist

- [x ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x ] I have followed the patterns in [PATTERNS.md](../PATTERNS.md)
- [x ] My code follows the existing style
- [ ] I have added documentation for new features
- [ ] All existing help patches still work
